### PR TITLE
降低 Android minSdkVersion 以适应更广

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,7 +32,7 @@ android {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 19
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -40,7 +40,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.hellobike.thrio_example"
-        minSdkVersion 21
+        minSdkVersion 19
         targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName


### PR DESCRIPTION
Android minSdkVersion 19 (4.4)

如果把里面的arrayMap换成 hashmap 或变更 arraymap 依赖为Androidx 
minSdkVersion 可降低至 Android 16 (4.1 flutter的最低支持版本)