### PR TITLE
pub 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,9 @@
 * feat: support for passing complex types between flutter pages
 * feat: support notify all page
 
-## 1.1.1
+## 1.2.0
 
-* fix: issue #123
+* fix: issue #123，解决`1.1.0`版本中存在的 pop native 到原生 poppedResult 不调用的问题
+* feat: 支持在所有页面间传递Json对象，为相关 API 添加泛型支持
+* feat: Flutter端添加 `lastRoute`,     `allRoutes` 两个新的 API
+* feat: 删除 `lastIndex`，`allIndexes` 这两个 API

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -6,7 +6,6 @@ analyzer:
     implicit-dynamic: true
   exclude:
     - lib/src/**.g.dart
-    - analysis_options.yaml
   enable-experiment:
     - extension-methods
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.hellobike.flutter.thrio'
-version '1.1.1'
+version '1.2.0'
 
 buildscript {
     ext.kotlin_version = '1.4.10'

--- a/android/src/main/kotlin/com/hellobike/flutter/thrio/ThrioTypes.kt
+++ b/android/src/main/kotlin/com/hellobike/flutter/thrio/ThrioTypes.kt
@@ -41,14 +41,24 @@ typealias NullableIntCallback = (Int?) -> Unit
 /**
  * Signature of callbacks with any parameters.
  */
-typealias NullableAnyCallback = (Any?) -> Unit
+typealias NullableAnyCallback<T> = (T?) -> Unit
+
+/**
+ * Signature for a block that serializer json object to map.
+ */
+typealias JsonSerializer<T> = (T) -> Map<String, Any?>?
+
+/**
+ * Signature for a block that deserialize json map to object.
+ */
+typealias JsonDeserializer<T> = (Map<String, Any?>) -> T?
 
 /**
  * Signature for a callbacks that handlers channel method invocation.
  */
-typealias MethodHandler = (Map<String, Any?>?, NullableAnyCallback) -> Unit
+typealias MethodHandler = (Map<String, Any?>?, NullableAnyCallback<*>) -> Unit
 
 /**
  * Signature for a callbacks that handlers channel event handling.
  */
-typealias EventHandler = (Map<String, Any?>?, NullableAnyCallback) -> Unit
+typealias EventHandler = (Map<String, Any?>?, NullableAnyCallback<*>) -> Unit

--- a/android/src/main/kotlin/com/hellobike/flutter/thrio/ThrioTypes.kt
+++ b/android/src/main/kotlin/com/hellobike/flutter/thrio/ThrioTypes.kt
@@ -41,7 +41,7 @@ typealias NullableIntCallback = (Int?) -> Unit
 /**
  * Signature of callbacks with any parameters.
  */
-typealias NullableAnyCallback<T> = (T?) -> Unit
+typealias NullableAnyCallback = (Any?) -> Unit
 
 /**
  * Signature for a block that serializer json object to map.
@@ -56,9 +56,9 @@ typealias JsonDeserializer<T> = (Map<String, Any?>) -> T?
 /**
  * Signature for a callbacks that handlers channel method invocation.
  */
-typealias MethodHandler = (Map<String, Any?>?, NullableAnyCallback<*>) -> Unit
+typealias MethodHandler = (Map<String, Any?>?, NullableAnyCallback) -> Unit
 
 /**
  * Signature for a callbacks that handlers channel event handling.
  */
-typealias EventHandler = (Map<String, Any?>?, NullableAnyCallback<*>) -> Unit
+typealias EventHandler = (Map<String, Any?>?, NullableAnyCallback) -> Unit

--- a/android/src/main/kotlin/com/hellobike/flutter/thrio/module/ModuleIntentBuilder.kt
+++ b/android/src/main/kotlin/com/hellobike/flutter/thrio/module/ModuleIntentBuilder.kt
@@ -23,12 +23,17 @@
 
 package com.hellobike.flutter.thrio.module
 
+import android.content.Context
 import com.hellobike.flutter.thrio.VoidCallback
 import com.hellobike.flutter.thrio.navigator.FlutterIntentBuilder
 import com.hellobike.flutter.thrio.navigator.IntentBuilder
 import com.hellobike.flutter.thrio.navigator.IntentBuilders
 
 interface ModuleIntentBuilder {
+
+    fun onIntentBuilderRegister(context: Context) {
+
+    }
 
     fun registerIntentBuilder(url: String, builder: IntentBuilder): VoidCallback {
         return IntentBuilders.intentBuilders.registry(url, builder)

--- a/android/src/main/kotlin/com/hellobike/flutter/thrio/module/ModuleJsonDeserializer.kt
+++ b/android/src/main/kotlin/com/hellobike/flutter/thrio/module/ModuleJsonDeserializer.kt
@@ -1,7 +1,7 @@
 /**
  * The MIT License (MIT)
  *
- * Copyright (c) 2019 Hellobike Group
+ * Copyright (c) 2020 foxsofter
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,21 +24,16 @@
 package com.hellobike.flutter.thrio.module
 
 import android.content.Context
+import com.hellobike.flutter.thrio.JsonDeserializer
 import com.hellobike.flutter.thrio.VoidCallback
-import com.hellobike.flutter.thrio.navigator.RouteObserver
-import com.hellobike.flutter.thrio.navigator.RouteObservers
+import com.hellobike.flutter.thrio.navigator.JsonDeserializers
 
-interface ModuleRouteObserver {
-
-    fun onRouteObserverRegister(context: Context) {
+interface ModuleJsonDeserializer {
+    fun onJsonDeserializerRegister(context: Context) {
 
     }
 
-    fun registerRouteObserver(observer: RouteObserver): VoidCallback {
-        return RouteObservers.observers.registry(observer)
-    }
-
-    fun registerRouteObservers(observers: List<RouteObserver>): VoidCallback {
-        return RouteObservers.observers.registryAll(observers.toSet())
+    fun <T> registerJsonDeserializer(deserializer: JsonDeserializer<T>, clazz: Class<T>): VoidCallback {
+        return JsonDeserializers.deserializers.registry(clazz.toString(), deserializer)
     }
 }

--- a/android/src/main/kotlin/com/hellobike/flutter/thrio/module/ModuleJsonSerializer.kt
+++ b/android/src/main/kotlin/com/hellobike/flutter/thrio/module/ModuleJsonSerializer.kt
@@ -1,7 +1,7 @@
 /**
  * The MIT License (MIT)
  *
- * Copyright (c) 2019 Hellobike Group
+ * Copyright (c) 2020 foxsofter
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,21 +24,16 @@
 package com.hellobike.flutter.thrio.module
 
 import android.content.Context
+import com.hellobike.flutter.thrio.JsonSerializer
 import com.hellobike.flutter.thrio.VoidCallback
-import com.hellobike.flutter.thrio.navigator.RouteObserver
-import com.hellobike.flutter.thrio.navigator.RouteObservers
+import com.hellobike.flutter.thrio.navigator.JsonSerializers
 
-interface ModuleRouteObserver {
-
-    fun onRouteObserverRegister(context: Context) {
+interface ModuleJsonSerializer {
+    fun onJsonSerializerRegister(context: Context) {
 
     }
 
-    fun registerRouteObserver(observer: RouteObserver): VoidCallback {
-        return RouteObservers.observers.registry(observer)
-    }
-
-    fun registerRouteObservers(observers: List<RouteObserver>): VoidCallback {
-        return RouteObservers.observers.registryAll(observers.toSet())
+    fun <T> registerJsonSerializer(serializer: JsonSerializer<T>, clazz: Class<T>): VoidCallback {
+        return JsonSerializers.serializers.registry(clazz.toString(), serializer)
     }
 }

--- a/android/src/main/kotlin/com/hellobike/flutter/thrio/module/ModulePageObserver.kt
+++ b/android/src/main/kotlin/com/hellobike/flutter/thrio/module/ModulePageObserver.kt
@@ -23,11 +23,16 @@
 
 package com.hellobike.flutter.thrio.module
 
+import android.content.Context
 import com.hellobike.flutter.thrio.VoidCallback
 import com.hellobike.flutter.thrio.navigator.PageObserver
 import com.hellobike.flutter.thrio.navigator.PageObservers
 
 interface ModulePageObserver {
+
+    fun onPageObserverRegister(context: Context) {
+
+    }
 
     fun registerPageObserver(observer: PageObserver): VoidCallback {
         return PageObservers.observers.registry(observer)

--- a/android/src/main/kotlin/com/hellobike/flutter/thrio/module/ThrioModule.kt
+++ b/android/src/main/kotlin/com/hellobike/flutter/thrio/module/ThrioModule.kt
@@ -67,14 +67,31 @@ open class ThrioModule {
             it.initModule(context)
         }
         modules.values.forEach {
-            it.onPageRegister(context)
+            if (it is ModuleIntentBuilder) {
+                it.onIntentBuilderRegister(context)
+            }
+        }
+        modules.values.forEach {
+            if (it is ModulePageObserver) {
+                it.onPageObserverRegister(context)
+            }
+            if (it is ModuleRouteObserver) {
+                it.onRouteObserverRegister(context)
+            }
+        }
+        modules.values.forEach {
+            if (it is ModuleJsonSerializer) {
+                it.onJsonSerializerRegister(context)
+            }
+            if (it is ModuleJsonDeserializer) {
+                it.onJsonDeserializerRegister(context)
+            }
         }
         startupFlutterEngine(context)
     }
 
     protected open fun onModuleRegister(context: Context) {}
 
-    protected open fun onPageRegister(context: Context) {}
 
     protected open fun onModuleInit(context: Context) {}
 

--- a/android/src/main/kotlin/com/hellobike/flutter/thrio/navigator/NavigationController.kt
+++ b/android/src/main/kotlin/com/hellobike/flutter/thrio/navigator/NavigationController.kt
@@ -78,13 +78,13 @@ internal object NavigationController : Application.ActivityLifecycleCallbacks {
     object Push {
 
         private var result: NullableIntCallback? = null
-        private var poppedResult: NullableAnyCallback? = null
+        private var poppedResult: NullableAnyCallback<*>? = null
 
-        fun push(url: String,
-                 params: Any? = null,
+        fun <T> push(url: String,
+                 params: T? = null,
                  animated: Boolean,
                  fromEntrypoint: String = "",
-                 poppedResult: NullableAnyCallback? = null,
+                 poppedResult: NullableAnyCallback<*>? = null,
                  result: NullableIntCallback?) {
             if (routeAction != RouteAction.NONE) {
                 result?.invoke(null)
@@ -97,7 +97,7 @@ internal object NavigationController : Application.ActivityLifecycleCallbacks {
             val index = (lastRoute?.settings?.index?.plus(1)) ?: 1
 
             val settings = RouteSettings(url, index).also {
-                it.params = params
+                it.params = JsonSerializers.serializeParams(params)
                 it.animated = animated
             }
 
@@ -199,17 +199,17 @@ internal object NavigationController : Application.ActivityLifecycleCallbacks {
 
     object Notify {
 
-        fun notify(url: String? = null,
+        fun <T> notify(url: String? = null,
                    index: Int? = null,
                    name: String,
-                   params: Any? = null,
+                   params: T? = null,
                    result: BooleanCallback? = null) {
             if ((url != null && index != null && index < 0) || !PageRoutes.hasRoute(url)) {
                 result?.invoke(false)
                 return
             }
 
-            PageRoutes.notify(url, index, name, params) {
+            PageRoutes.notify<T>(url, index, name, params) {
                 result?.invoke(it)
             }
 
@@ -235,7 +235,7 @@ internal object NavigationController : Application.ActivityLifecycleCallbacks {
                             "url" to route.settings.url,
                             "index" to route.settings.index,
                             "name" to it.key,
-                            "params" to it.value!!
+                            "params" to JsonSerializers.serializeParams(it.value)
                     )
                     Log.i("Thrio", "page ${route.settings.url} '" +
                             "'index ${route.settings.index} notify")
@@ -248,7 +248,7 @@ internal object NavigationController : Application.ActivityLifecycleCallbacks {
     }
 
     object Pop {
-        fun pop(params: Any? = null,
+        fun <T> pop(params: T? = null,
                 animated: Boolean = true,
                 result: BooleanCallback? = null) {
             if (routeAction != RouteAction.NONE) {
@@ -258,7 +258,7 @@ internal object NavigationController : Application.ActivityLifecycleCallbacks {
 
             routeAction = RouteAction.POP
 
-            PageRoutes.pop(params, animated) {
+            PageRoutes.pop<T>(params, animated) {
                 result?.invoke(it)
                 routeAction = RouteAction.NONE
             }

--- a/android/src/main/kotlin/com/hellobike/flutter/thrio/navigator/NavigationController.kt
+++ b/android/src/main/kotlin/com/hellobike/flutter/thrio/navigator/NavigationController.kt
@@ -36,7 +36,7 @@ import io.flutter.embedding.android.ThrioActivity
 internal object NavigationController : Application.ActivityLifecycleCallbacks {
 
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
-        context = context ?: activity
+        context = activity
 
         Remove.doRemove(activity)
         if (activity is ThrioActivity) {
@@ -78,14 +78,14 @@ internal object NavigationController : Application.ActivityLifecycleCallbacks {
     object Push {
 
         private var result: NullableIntCallback? = null
-        private var poppedResult: NullableAnyCallback<*>? = null
+        private var poppedResult: NullableAnyCallback? = null
 
         fun <T> push(url: String,
-                 params: T? = null,
-                 animated: Boolean,
-                 fromEntrypoint: String = "",
-                 poppedResult: NullableAnyCallback<*>? = null,
-                 result: NullableIntCallback?) {
+                     params: T? = null,
+                     animated: Boolean,
+                     fromEntrypoint: String = "",
+                     poppedResult: NullableAnyCallback? = null,
+                     result: NullableIntCallback?) {
             if (routeAction != RouteAction.NONE) {
                 result?.invoke(null)
                 return
@@ -200,10 +200,10 @@ internal object NavigationController : Application.ActivityLifecycleCallbacks {
     object Notify {
 
         fun <T> notify(url: String? = null,
-                   index: Int? = null,
-                   name: String,
-                   params: T? = null,
-                   result: BooleanCallback? = null) {
+                       index: Int? = null,
+                       name: String,
+                       params: T? = null,
+                       result: BooleanCallback? = null) {
             if ((url != null && index != null && index < 0) || !PageRoutes.hasRoute(url)) {
                 result?.invoke(false)
                 return
@@ -237,8 +237,7 @@ internal object NavigationController : Application.ActivityLifecycleCallbacks {
                             "name" to it.key,
                             "params" to JsonSerializers.serializeParams(it.value)
                     )
-                    Log.i("Thrio", "page ${route.settings.url} '" +
-                            "'index ${route.settings.index} notify")
+                    Log.i("Thrio", "url-> ${route.settings.url} index-> ${route.settings.index} notify")
                     activity.onNotify(arguments) {}
                 } else if (activity is PageNotifyListener) {
                     activity.onNotify(it.key, it.value)
@@ -249,8 +248,8 @@ internal object NavigationController : Application.ActivityLifecycleCallbacks {
 
     object Pop {
         fun <T> pop(params: T? = null,
-                animated: Boolean = true,
-                result: BooleanCallback? = null) {
+                    animated: Boolean = true,
+                    result: BooleanCallback? = null) {
             if (routeAction != RouteAction.NONE) {
                 result?.invoke(false)
                 return

--- a/android/src/main/kotlin/com/hellobike/flutter/thrio/navigator/PageObserverChannel.kt
+++ b/android/src/main/kotlin/com/hellobike/flutter/thrio/navigator/PageObserverChannel.kt
@@ -54,18 +54,22 @@ class PageObserverChannel constructor(entrypoint: String, messenger: BinaryMesse
     }
 
     override fun willAppear(routeSettings: RouteSettings) {
-        channel.invokeMethod("willAppear", routeSettings.toArguments())
+        val arguments = routeSettings.toArgumentsWithParams(null);
+        channel.invokeMethod("willAppear", arguments)
     }
 
     override fun didAppear(routeSettings: RouteSettings) {
-        channel.invokeMethod("didAppear", routeSettings.toArguments())
+        val arguments = routeSettings.toArgumentsWithParams(null);
+        channel.invokeMethod("didAppear", arguments)
     }
 
     override fun willDisappear(routeSettings: RouteSettings) {
-        channel.invokeMethod("willDisappear", routeSettings.toArguments())
+        val arguments = routeSettings.toArgumentsWithParams(null);
+        channel.invokeMethod("willDisappear", arguments)
     }
 
     override fun didDisappear(routeSettings: RouteSettings) {
-        channel.invokeMethod("didDisappear", routeSettings.toArguments())
+        val arguments = routeSettings.toArgumentsWithParams(null);
+        channel.invokeMethod("didDisappear", arguments)
     }
 }

--- a/android/src/main/kotlin/com/hellobike/flutter/thrio/navigator/PageObservers.kt
+++ b/android/src/main/kotlin/com/hellobike/flutter/thrio/navigator/PageObservers.kt
@@ -39,8 +39,7 @@ internal object PageObservers : PageObserver {
             it.willAppear(routeSettings)
         }
         Log.i(TAG, "willAppear: url->${routeSettings.url} " +
-                "index->${routeSettings.index} " +
-                "params->${routeSettings.params?.toString()}")
+                "index->${routeSettings.index} ")
     }
 
     override fun didAppear(routeSettings: RouteSettings) {
@@ -48,8 +47,7 @@ internal object PageObservers : PageObserver {
             it.didAppear(routeSettings)
         }
         Log.i(TAG, "didAppear: url->${routeSettings.url} " +
-                "index->${routeSettings.index} " +
-                "params->${routeSettings.params?.toString()}")
+                "index->${routeSettings.index} ")
         PageRoutes.lastRouteHolder(routeSettings.url, routeSettings.index)?.activity?.get()?.apply {
             NavigationController.Notify.doNotify(this)
         }
@@ -60,8 +58,7 @@ internal object PageObservers : PageObserver {
             it.willDisappear(routeSettings)
         }
         Log.i(TAG, "willDisappear: url->${routeSettings.url} " +
-                "index->${routeSettings.index} " +
-                "params->${routeSettings.params?.toString()}")
+                "index->${routeSettings.index} ")
     }
 
     override fun didDisappear(routeSettings: RouteSettings) {
@@ -69,7 +66,6 @@ internal object PageObservers : PageObserver {
             it.didDisappear(routeSettings)
         }
         Log.i(TAG, "didDisappear: url->${routeSettings.url} " +
-                "index->${routeSettings.index} " +
-                "params->${routeSettings.params?.toString()}")
+                "index->${routeSettings.index} ")
     }
 }

--- a/android/src/main/kotlin/com/hellobike/flutter/thrio/navigator/PageRoute.kt
+++ b/android/src/main/kotlin/com/hellobike/flutter/thrio/navigator/PageRoute.kt
@@ -33,7 +33,7 @@ data class PageRoute(val settings: RouteSettings, val clazz: Class<out Activity>
     var entrypoint: String = NAVIGATION_FLUTTER_ENTRYPOINT_DEFAULT
     var fromEntrypoint: String = NAVIGATION_NATIVE_ENTRYPOINT
 
-    var poppedResult: NullableAnyCallback<*>? = null
+    var poppedResult: NullableAnyCallback? = null
 
     fun <T> addNotify(name: String, params: T?) {
         notifications[name] = params

--- a/android/src/main/kotlin/com/hellobike/flutter/thrio/navigator/PageRouteHolder.kt
+++ b/android/src/main/kotlin/com/hellobike/flutter/thrio/navigator/PageRouteHolder.kt
@@ -25,8 +25,8 @@ package com.hellobike.flutter.thrio.navigator
 
 import android.app.Activity
 import com.hellobike.flutter.thrio.BooleanCallback
-import com.hellobike.flutter.thrio.NullableAnyCallback
 import com.hellobike.flutter.thrio.NullableIntCallback
+import com.hellobike.flutter.thrio.NullableAnyCallback
 import io.flutter.embedding.android.ThrioActivity
 import java.lang.ref.WeakReference
 
@@ -118,7 +118,7 @@ internal data class PageRouteHolder(val pageId: Int,
                     if (it) {
                         lastRoute.poppedResult?.let {
                             @Suppress("UNCHECKED_CAST")
-                            (it as NullableAnyCallback<T>)(params)
+                            it(JsonDeserializers.deserializeParams(params))
                         }
                         lastRoute.poppedResult = null
                         if (lastRoute.fromEntrypoint != NAVIGATION_NATIVE_ENTRYPOINT
@@ -133,7 +133,7 @@ internal data class PageRouteHolder(val pageId: Int,
                 result(true)
                 lastRoute.poppedResult?.let {
                     @Suppress("UNCHECKED_CAST")
-                    (it as NullableAnyCallback<T>)(params)
+                    it(JsonDeserializers.deserializeParams(params))
                 }
                 lastRoute.poppedResult = null
                 if (lastRoute.fromEntrypoint != NAVIGATION_NATIVE_ENTRYPOINT) {

--- a/android/src/main/kotlin/com/hellobike/flutter/thrio/navigator/PageRoutes.kt
+++ b/android/src/main/kotlin/com/hellobike/flutter/thrio/navigator/PageRoutes.kt
@@ -95,7 +95,7 @@ internal object PageRoutes : Application.ActivityLifecycleCallbacks {
         return holder?.lastRoute()
     }
 
-    fun allRoutes(url: String): List<PageRoute> {
+    fun allRoutes(url: String? = null): List<PageRoute> {
         val allRoutes = mutableListOf<PageRoute>()
         for (i in routeHolders.size - 1 downTo 0) {
             val holder = routeHolders[i]
@@ -118,10 +118,10 @@ internal object PageRoutes : Application.ActivityLifecycleCallbacks {
         holder.push(route, result)
     }
 
-    fun notify(url: String?,
+    fun <T> notify(url: String?,
                index: Int?,
                name: String,
-               params: Any?,
+               params: T?,
                result: BooleanCallback) {
         if (!hasRoute(url, index)) {
             result(false)
@@ -130,14 +130,14 @@ internal object PageRoutes : Application.ActivityLifecycleCallbacks {
 
         var isMatch = false
         routeHolders.forEach { holder ->
-            holder.notify(url, index, name, params) {
+            holder.notify<T>(url, index, name, params) {
                 if (it) isMatch = true
             }
         }
         result(isMatch)
     }
 
-    fun pop(params: Any?, animated: Boolean, result: BooleanCallback) {
+    fun <T> pop(params: T?, animated: Boolean, result: BooleanCallback) {
         val holder = routeHolders.lastOrNull()
         if (holder == null) {
             result(false)
@@ -148,7 +148,7 @@ internal object PageRoutes : Application.ActivityLifecycleCallbacks {
             holder.activity?.get()?.finish()
             result(true)
         } else {
-            holder.pop(params, animated) { it ->
+            holder.pop<T>(params, animated) { it ->
                 if (it) {
                     if (!holder.hasRoute()) {
                         holder.activity?.get()?.let {

--- a/android/src/main/kotlin/com/hellobike/flutter/thrio/navigator/RouteObserverChannel.kt
+++ b/android/src/main/kotlin/com/hellobike/flutter/thrio/navigator/RouteObserverChannel.kt
@@ -39,19 +39,23 @@ class RouteObserverChannel constructor(entrypoint: String, messenger: BinaryMess
     }
 
     override fun didPush(routeSettings: RouteSettings) {
-        channel.invokeMethod("didPush", routeSettings.toArguments())
+        val arguments = routeSettings.toArgumentsWithParams(null);
+        channel.invokeMethod("didPush", arguments)
     }
 
     override fun didPop(routeSettings: RouteSettings) {
-        channel.invokeMethod("didPop", routeSettings.toArguments())
+        val arguments = routeSettings.toArgumentsWithParams(null);
+        channel.invokeMethod("didPop", arguments)
     }
 
     override fun didPopTo(routeSettings: RouteSettings) {
-        channel.invokeMethod("didPopTo", routeSettings.toArguments())
+        val arguments = routeSettings.toArgumentsWithParams(null);
+        channel.invokeMethod("didPopTo", arguments)
     }
 
     override fun didRemove(routeSettings: RouteSettings) {
-        channel.invokeMethod("didRemove", routeSettings.toArguments())
+        val arguments = routeSettings.toArgumentsWithParams(null);
+        channel.invokeMethod("didRemove", arguments)
     }
 
     private fun on(method: String) {

--- a/android/src/main/kotlin/com/hellobike/flutter/thrio/navigator/RouteObservers.kt
+++ b/android/src/main/kotlin/com/hellobike/flutter/thrio/navigator/RouteObservers.kt
@@ -36,8 +36,7 @@ internal object RouteObservers : RouteObserver {
 
     override fun didPush(routeSettings: RouteSettings) {
         Log.i(TAG, "didPush: url->${routeSettings.url} " +
-                "index->${routeSettings.index} " +
-                "params->${routeSettings.params?.toString()}")
+                "index->${routeSettings.index} ")
         observers.forEach {
             it.didPush(routeSettings)
         }
@@ -45,8 +44,7 @@ internal object RouteObservers : RouteObserver {
 
     override fun didPop(routeSettings: RouteSettings) {
         Log.i(TAG, "didPop: url->${routeSettings.url} " +
-                "index->${routeSettings.index} " +
-                "params->${routeSettings.params?.toString()}")
+                "index->${routeSettings.index} ")
         observers.forEach {
             it.didPop(routeSettings)
         }
@@ -54,8 +52,7 @@ internal object RouteObservers : RouteObserver {
 
     override fun didPopTo(routeSettings: RouteSettings) {
         Log.i(TAG, "didPopTo: url->${routeSettings.url} " +
-                "index->${routeSettings.index} " +
-                "params->${routeSettings.params?.toString()}")
+                "index->${routeSettings.index} ")
         observers.forEach {
             it.didPopTo(routeSettings)
         }
@@ -63,8 +60,7 @@ internal object RouteObservers : RouteObserver {
 
     override fun didRemove(routeSettings: RouteSettings) {
         Log.i(TAG, "didRemove: url->${routeSettings.url} " +
-                "index->${routeSettings.index} " +
-                "params->${routeSettings.params?.toString()}")
+                "index->${routeSettings.index} ")
         observers.forEach {
             it.didRemove(routeSettings)
         }

--- a/android/src/main/kotlin/com/hellobike/flutter/thrio/navigator/RouteReceiveChannel.kt
+++ b/android/src/main/kotlin/com/hellobike/flutter/thrio/navigator/RouteReceiveChannel.kt
@@ -34,8 +34,10 @@ internal class RouteReceiveChannel(val channel: ThrioChannel,
         onPop()
         onPopTo()
         onRemove()
-        onLastIndex()
-        onGetAllIndexes()
+
+        onLastRoute()
+        onGetAllRoutes()
+
         onSetPopDisabled()
         onHotRestart()
         onRegisterUrls()
@@ -99,12 +101,23 @@ internal class RouteReceiveChannel(val channel: ThrioChannel,
         }
     }
 
-    private fun onLastIndex() {
-        channel.registryMethod("lastIndex") { _, _ -> }
+    private fun onLastRoute() {
+        channel.registryMethod("lastRoute") { arguments, result ->
+            if (arguments == null) return@registryMethod
+            val url = if (arguments["url"] != null) arguments["url"] as String else null
+            val route = ThrioNavigator.lastRoute(url)
+            result(route?.settings?.name)
+        }
     }
 
-    private fun onGetAllIndexes() {
-        channel.registryMethod("allIndexes") { _, _ -> }
+    private fun onGetAllRoutes() {
+        channel.registryMethod("allRoutes") { arguments, result ->
+            if (arguments == null) return@registryMethod
+            val url = if (arguments["url"] != null) arguments["url"] as String else null
+            val routes = ThrioNavigator.allRoutes(url)
+            val routeNames = routes.map { it.settings.name }
+            result(routeNames)
+        }
     }
 
     private fun onSetPopDisabled() {

--- a/android/src/main/kotlin/com/hellobike/flutter/thrio/navigator/RouteReceiveChannel.kt
+++ b/android/src/main/kotlin/com/hellobike/flutter/thrio/navigator/RouteReceiveChannel.kt
@@ -68,7 +68,9 @@ internal class RouteReceiveChannel(val channel: ThrioChannel,
             val index = if (arguments["index"] != null) arguments["index"] as Int else 0
             val name = arguments["name"] as String
             val params = arguments["params"]
-            NavigationController.Notify.notify(url, index, name, params, result)
+            NavigationController.Notify.notify(url, index, name, params){
+                result(it)
+            }
         }
     }
 

--- a/android/src/main/kotlin/com/hellobike/flutter/thrio/navigator/RouteSettings.kt
+++ b/android/src/main/kotlin/com/hellobike/flutter/thrio/navigator/RouteSettings.kt
@@ -29,6 +29,8 @@ data class RouteSettings(val url: String, val index: Int) {
     var animated: Boolean = true
     var isNested: Boolean = false
 
+    val name get() = "$index $url"
+
     fun toArguments(): Map<String, Any?> = mapOf(
             "url" to url,
             "index" to index,
@@ -53,7 +55,7 @@ data class RouteSettings(val url: String, val index: Int) {
             }
             val url = arguments["url"] as String
             val index = if (arguments["index"] != null) arguments["index"] as Int else 0
-            val params = arguments["params"]
+            val params = JsonDeserializers.deserializeParams(arguments["params"])
             val animated = if (arguments["animated"] != null) arguments["animated"] as Boolean else false
             return RouteSettings(url, index).also {
                 it.params = params

--- a/android/src/main/kotlin/com/hellobike/flutter/thrio/navigator/RouteSettings.kt
+++ b/android/src/main/kotlin/com/hellobike/flutter/thrio/navigator/RouteSettings.kt
@@ -39,6 +39,20 @@ data class RouteSettings(val url: String, val index: Int) {
             "params" to params
     )
 
+    fun toArgumentsWithParams(params: Any?): Map<String, Any?> = when (params) {
+        null -> mapOf(
+                "url" to url,
+                "index" to index,
+                "animated" to animated,
+                "isNested" to isNested)
+        else -> mapOf(
+                "url" to url,
+                "index" to index,
+                "animated" to animated,
+                "isNested" to isNested,
+                "params" to params)
+    }
+
     override fun equals(other: Any?): Boolean {
         return other != null && other is RouteSettings && url == other.url && index == other.index
     }

--- a/android/src/main/kotlin/com/hellobike/flutter/thrio/navigator/ThrioNavigator.kt
+++ b/android/src/main/kotlin/com/hellobike/flutter/thrio/navigator/ThrioNavigator.kt
@@ -23,7 +23,6 @@
 
 package com.hellobike.flutter.thrio.navigator
 
-import android.app.Application
 import com.hellobike.flutter.thrio.BooleanCallback
 import com.hellobike.flutter.thrio.NullableAnyCallback
 import com.hellobike.flutter.thrio.NullableIntCallback
@@ -33,30 +32,52 @@ object ThrioNavigator {
     @JvmStatic
     @JvmOverloads
     fun <T> push(url: String,
-             params: T? = null,
-             animated: Boolean = true,
-             poppedResult: NullableAnyCallback<*>? = null,
-             result: NullableIntCallback = {}) {
+                       params: T? = null,
+                       animated: Boolean = true,
+                       poppedResult: NullableAnyCallback? = null,
+                       result: NullableIntCallback = {}) {
         NavigationController.Push.push<T>(url, params, animated,
+                NAVIGATION_NATIVE_ENTRYPOINT, poppedResult, result)
+    }
+
+    @JvmStatic
+    fun push(url: String,
+             animated: Boolean = true,
+             poppedResult: NullableAnyCallback? = null,
+             result: NullableIntCallback = {}) {
+        NavigationController.Push.push(url, null, animated,
                 NAVIGATION_NATIVE_ENTRYPOINT, poppedResult, result)
     }
 
     @JvmStatic
     @JvmOverloads
     fun <T> notify(url: String? = null,
+                   index: Int = 0,
+                   name: String,
+                   params: T? = null,
+                   result: BooleanCallback = {}) {
+        NavigationController.Notify.notify<T>(url, index, name, params, result)
+    }
+
+    @JvmStatic
+    fun notify(url: String? = null,
                index: Int = 0,
                name: String,
-               params: T? = null,
                result: BooleanCallback = {}) {
-        NavigationController.Notify.notify<T>(url, index, name, params, result)
+        NavigationController.Notify.notify(url, index, name, null, result)
     }
 
     @JvmStatic
     @JvmOverloads
     fun <T> pop(params: T? = null,
-            animated: Boolean = true,
-            result: BooleanCallback = {}) {
+                animated: Boolean = true,
+                result: BooleanCallback = {}) {
         NavigationController.Pop.pop<T>(params, animated, result)
+    }
+
+    @JvmStatic
+    fun pop(animated: Boolean = true, result: BooleanCallback = {}) {
+        NavigationController.Pop.pop(null, animated, result)
     }
 
     @JvmStatic

--- a/android/src/main/kotlin/com/hellobike/flutter/thrio/navigator/ThrioNavigator.kt
+++ b/android/src/main/kotlin/com/hellobike/flutter/thrio/navigator/ThrioNavigator.kt
@@ -32,31 +32,31 @@ object ThrioNavigator {
 
     @JvmStatic
     @JvmOverloads
-    fun push(url: String,
-             params: Any? = null,
+    fun <T> push(url: String,
+             params: T? = null,
              animated: Boolean = true,
-             poppedResult: NullableAnyCallback? = null,
+             poppedResult: NullableAnyCallback<*>? = null,
              result: NullableIntCallback = {}) {
-        NavigationController.Push.push(url, params, animated,
+        NavigationController.Push.push<T>(url, params, animated,
                 NAVIGATION_NATIVE_ENTRYPOINT, poppedResult, result)
     }
 
     @JvmStatic
     @JvmOverloads
-    fun notify(url: String? = null,
+    fun <T> notify(url: String? = null,
                index: Int = 0,
                name: String,
-               params: Any? = null,
+               params: T? = null,
                result: BooleanCallback = {}) {
-        NavigationController.Notify.notify(url, index, name, params, result)
+        NavigationController.Notify.notify<T>(url, index, name, params, result)
     }
 
     @JvmStatic
     @JvmOverloads
-    fun pop(params: Any? = null,
+    fun <T> pop(params: T? = null,
             animated: Boolean = true,
             result: BooleanCallback = {}) {
-        NavigationController.Pop.pop(params, animated, result)
+        NavigationController.Pop.pop<T>(params, animated, result)
     }
 
     @JvmStatic
@@ -83,5 +83,6 @@ object ThrioNavigator {
     fun lastRoute(url: String? = null): PageRoute? = PageRoutes.lastRoute(url)
 
     @JvmStatic
-    fun allRoutes(url: String): List<PageRoute> = PageRoutes.allRoutes(url);
+    @JvmOverloads
+    fun allRoutes(url: String? = null): List<PageRoute> = PageRoutes.allRoutes(url);
 }

--- a/android/src/main/kotlin/io/flutter/embedding/android/ThrioActivity.kt
+++ b/android/src/main/kotlin/io/flutter/embedding/android/ThrioActivity.kt
@@ -25,7 +25,7 @@ package io.flutter.embedding.android
 
 import android.content.Intent
 import com.hellobike.flutter.thrio.BooleanCallback
-import com.hellobike.flutter.thrio.navigator.FlutterEngineFactory
+import com.hellobike.flutter.thrio.navigator.*
 import com.hellobike.flutter.thrio.navigator.NavigationController
 import com.hellobike.flutter.thrio.navigator.PageRoutes
 import com.hellobike.flutter.thrio.navigator.getPageId
@@ -60,7 +60,7 @@ open class ThrioActivity : ThrioFlutterActivity() {
                     return
                 }
             }
-            NavigationController.Pop.pop()
+            ThrioNavigator.pop()
         }
     }
 

--- a/example/android/app/src/main/kotlin/com/hellobike/thrio_example/MainModule.kt
+++ b/example/android/app/src/main/kotlin/com/hellobike/thrio_example/MainModule.kt
@@ -3,11 +3,13 @@ package com.hellobike.thrio_example
 import android.app.Activity
 import android.content.Context
 import com.hellobike.flutter.thrio.module.ModuleIntentBuilder
+import com.hellobike.flutter.thrio.module.ModuleJsonDeserializer
+import com.hellobike.flutter.thrio.module.ModuleJsonSerializer
 import com.hellobike.flutter.thrio.module.ThrioModule
 import com.hellobike.flutter.thrio.navigator.FlutterIntentBuilder
 import com.hellobike.flutter.thrio.navigator.IntentBuilder
 
-object MainModule : ThrioModule(), ModuleIntentBuilder {
+object MainModule : ThrioModule(), ModuleIntentBuilder, ModuleJsonSerializer, ModuleJsonDeserializer {
 
     override fun onModuleInit(context: Context) {
         setFlutterIntentBuilder(object : FlutterIntentBuilder() {
@@ -16,7 +18,7 @@ object MainModule : ThrioModule(), ModuleIntentBuilder {
         navigatorLogEnabled = true
     }
 
-    override fun onPageRegister(context: Context) {
+    override fun onIntentBuilderRegister(context: Context) {
         registerIntentBuilder("/biz1/native1", object : IntentBuilder {
             override fun getActivityClz(): Class<out Activity> {
                 return Native1Activity::class.java
@@ -27,5 +29,13 @@ object MainModule : ThrioModule(), ModuleIntentBuilder {
                 return Native2Activity::class.java
             }
         })
+    }
+
+    override fun onJsonSerializerRegister(context: Context) {
+        registerJsonSerializer({ people -> people.toJson() }, People::class.java)
+    }
+
+    override fun onJsonDeserializerRegister(context: Context) {
+        registerJsonDeserializer({ json -> People(json) }, People::class.java)
     }
 }

--- a/example/android/app/src/main/kotlin/com/hellobike/thrio_example/Native1Activity.kt
+++ b/example/android/app/src/main/kotlin/com/hellobike/thrio_example/Native1Activity.kt
@@ -15,7 +15,10 @@ class Native1Activity : AppCompatActivity(), PageNotifyListener {
 
         btn_10.setOnClickListener {
             ThrioNavigator.push("/biz1/flutter1",
-                    params = mapOf("k1" to 1),
+                    params = People(mapOf(
+                            "name" to "foxsofter",
+                            "age" to 100,
+                            "sex" to "x")),
                     result = {
                         Log.i("Thrio", "push result data $it")
                     },
@@ -84,7 +87,10 @@ class Native1Activity : AppCompatActivity(), PageNotifyListener {
         }
 
         btn_3.setOnClickListener {
-            ThrioNavigator.pop("native 1 popResult")
+            ThrioNavigator.pop( People(mapOf(
+                    "name" to "foxsofter",
+                    "age" to 100,
+                    "sex" to "from pop")))
         }
     }
 

--- a/example/android/app/src/main/kotlin/com/hellobike/thrio_example/People.kt
+++ b/example/android/app/src/main/kotlin/com/hellobike/thrio_example/People.kt
@@ -1,0 +1,11 @@
+package com.hellobike.thrio_example
+
+data class People(val props: Map<String, Any?>) {
+    val name: String by props
+    val age: Long by props
+    val sex: String by props
+
+    fun toJson(): Map<String, Any?> {
+        return props
+    }
+}

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		BBF2756AA90F3981ABC78E75 /* libPods-Runner.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 80FC86B336259FEEC5E93BBC /* libPods-Runner.a */; };
+		DC78D64F257D34E600174064 /* THRPeople.m in Sources */ = {isa = PBXBuildFile; fileRef = DC78D64E257D34E600174064 /* THRPeople.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -93,6 +94,8 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DC78D64D257D34E600174064 /* THRPeople.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = THRPeople.h; sourceTree = "<group>"; };
+		DC78D64E257D34E600174064 /* THRPeople.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = THRPeople.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -184,6 +187,8 @@
 				8E4A6A89240227C9009DCF21 /* SampleModule.m */,
 				12F239B825548D9A00C1370C /* CustomFlutterViewController.h */,
 				12F239B925548D9A00C1370C /* CustomFlutterViewController.m */,
+				DC78D64D257D34E600174064 /* THRPeople.h */,
+				DC78D64E257D34E600174064 /* THRPeople.m */,
 			);
 			name = Sample;
 			sourceTree = "<group>";
@@ -472,6 +477,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DC78D64F257D34E600174064 /* THRPeople.m in Sources */,
 				12F239BA25548D9A00C1370C /* CustomFlutterViewController.m in Sources */,
 				8E4A6A90240228D6009DCF21 /* Module1.m in Sources */,
 				12A48B9723E6D58E002B699E /* ThrioViewController2.m in Sources */,

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1210"
+   LastUpgradeVersion = "1220"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/example/ios/Runner/CustomFlutterViewController.h
+++ b/example/ios/Runner/CustomFlutterViewController.h
@@ -3,7 +3,7 @@
 //  Runner
 //
 //  Created by foxsofter on 2020/11/6.
-//  Copyright © 2020 The Chromium Authors. All rights reserved.
+//  Copyright © 2020 foxsofter. All rights reserved.
 //
 
 #import <thrio/Thrio.h>

--- a/example/ios/Runner/CustomFlutterViewController.m
+++ b/example/ios/Runner/CustomFlutterViewController.m
@@ -3,7 +3,7 @@
 //  Runner
 //
 //  Created by foxsofter on 2020/11/6.
-//  Copyright © 2020 The Chromium Authors. All rights reserved.
+//  Copyright © 2020 foxsofter. All rights reserved.
 //
 
 #import "CustomFlutterViewController.h"

--- a/example/ios/Runner/MainModule.h
+++ b/example/ios/Runner/MainModule.h
@@ -3,14 +3,14 @@
 //  Runner
 //
 //  Created by foxsofter on 2019/12/28.
-//  Copyright © 2019 The Chromium Authors. All rights reserved.
+//  Copyright © 2019 foxsofter. All rights reserved.
 //
 
 #import <thrio/Thrio.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface MainModule : ThrioModule<ThrioModulePageObserver>
+@interface MainModule : ThrioModule<ThrioModulePageBuilder>
 
 @end
 

--- a/example/ios/Runner/MainModule.m
+++ b/example/ios/Runner/MainModule.m
@@ -3,17 +3,21 @@
 //  Runner
 //
 //  Created by foxsofter on 2019/12/28.
-//  Copyright © 2019 The Chromium Authors. All rights reserved.
+//  Copyright © 2019 foxsofter. All rights reserved.
 //
 
 @import thrio;
 #import "MainModule.h"
 #import "SampleModule.h"
+#import "CustomFlutterViewController.h"
 #import <Runner-Swift.h>
 
 @implementation MainModule
 
 - (void)onModuleInit {
+    [self setFlutterPageBuilder:^(NSString *entrypoint) {
+        return [[CustomFlutterViewController alloc] initWithEntrypoint:entrypoint];
+    }];
 }
 
 - (void)onModuleRegister {

--- a/example/ios/Runner/Module1.h
+++ b/example/ios/Runner/Module1.h
@@ -3,14 +3,15 @@
 //  Runner
 //
 //  Created by foxsofter on 2020/2/23.
-//  Copyright © 2020 The Chromium Authors. All rights reserved.
+//  Copyright © 2020 foxsofter. All rights reserved.
 //
 
 #import <thrio/Thrio.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface Module1 : ThrioModule<ThrioModulePageObserver,
+@interface Module1 : ThrioModule<ThrioModulePageBuilder,
+                                 ThrioModulePageObserver,
                                  NavigatorPageObserverProtocol>
 
 @end

--- a/example/ios/Runner/Module1.m
+++ b/example/ios/Runner/Module1.m
@@ -3,7 +3,7 @@
 //  Runner
 //
 //  Created by foxsofter on 2020/2/23.
-//  Copyright © 2020 The Chromium Authors. All rights reserved.
+//  Copyright © 2020 foxsofter. All rights reserved.
 //
 
 #import "Module1.h"
@@ -11,16 +11,15 @@
 
 @implementation Module1
 
-- (void)onPageRegister {
-    [self
-     registerPageBuilder:^UIViewController *_Nullable (
-         NSDictionary<NSString *, id> *_Nonnull params) {
+- (void)onPageBuilderRegister {
+    [self registerPageBuilder:^UIViewController *_Nullable (id params) {
+        ThrioLogI(@"/biz1/native1 pushed params: %@", params);
         UIStoryboard *sb = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
-        return
-        [sb instantiateViewControllerWithIdentifier:@"ThrioViewController"];
-    }
-                  forUrl:@"/biz1/native1"];
+        return [sb instantiateViewControllerWithIdentifier:@"ThrioViewController"];
+    } forUrl:@"/biz1/native1"];
+}
 
+- (void)onPageObserverRegister {
     [self registerPageObserver:self];
 }
 

--- a/example/ios/Runner/Module2.h
+++ b/example/ios/Runner/Module2.h
@@ -3,14 +3,15 @@
 //  Runner
 //
 //  Created by foxsofter on 2020/2/23.
-//  Copyright © 2020 The Chromium Authors. All rights reserved.
+//  Copyright © 2020 foxsofter. All rights reserved.
 //
 
 #import <thrio/Thrio.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface Module2 : ThrioModule<ThrioModuleRouteObserver,
+@interface Module2 : ThrioModule<ThrioModulePageBuilder,
+                                 ThrioModuleRouteObserver,
                                  NavigatorRouteObserverProtocol>
 
 @end

--- a/example/ios/Runner/Module2.m
+++ b/example/ios/Runner/Module2.m
@@ -3,7 +3,7 @@
 //  Runner
 //
 //  Created by foxsofter on 2020/2/23.
-//  Copyright © 2020 The Chromium Authors. All rights reserved.
+//  Copyright © 2020 foxsofter. All rights reserved.
 //
 
 #import "Module2.h"
@@ -13,16 +13,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation Module2
 
-- (void)onPageRegister {
-    [self
-     registerPageBuilder:^UIViewController *_Nullable (
-         NSDictionary<NSString *, id> *_params) {
+- (void)onPageBuilderRegister {
+    [self registerPageBuilder:^UIViewController *_Nullable (id params) {
         UIStoryboard *sb = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
-        return [sb
-                instantiateViewControllerWithIdentifier:@"ThrioViewController2"];
-    }
-                  forUrl:@"/biz2/native2"];
+        return [sb instantiateViewControllerWithIdentifier:@"ThrioViewController2"];
+    } forUrl:@"/biz2/native2"];
+}
 
+- (void)onRouteObserverRegister {
     [self registerRouteObserver:self];
 }
 

--- a/example/ios/Runner/Page5View.swift
+++ b/example/ios/Runner/Page5View.swift
@@ -3,7 +3,7 @@
 //  Runner
 //
 //  Created by foxsofter on 2020/11/2.
-//  Copyright © 2020 The Chromium Authors. All rights reserved.
+//  Copyright © 2020 foxsofter. All rights reserved.
 //
 
 import SwiftUI

--- a/example/ios/Runner/SampleModule.h
+++ b/example/ios/Runner/SampleModule.h
@@ -3,14 +3,15 @@
 //  Runner
 //
 //  Created by foxsofter on 2020/2/23.
-//  Copyright © 2020 The Chromium Authors. All rights reserved.
+//  Copyright © 2020 foxsofter. All rights reserved.
 //
 
 #import <thrio/Thrio.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SampleModule : ThrioModule
+@interface SampleModule : ThrioModule<ThrioModuleJsonSerializer,
+                                      ThrioModuleJsonDeserializer>
 
 @end
 

--- a/example/ios/Runner/SampleModule.m
+++ b/example/ios/Runner/SampleModule.m
@@ -3,13 +3,15 @@
 //  Runner
 //
 //  Created by foxsofter on 2020/2/23.
-//  Copyright © 2020 The Chromium Authors. All rights reserved.
+//  Copyright © 2020 foxsofter. All rights reserved.
 //
 
 #import "SampleModule.h"
 #import "Module1.h"
 #import "Module2.h"
-#import "CustomFlutterViewController.h"
+#import "THRPeople.h"
+
+NS_ASSUME_NONNULL_BEGIN
 
 @implementation SampleModule
 
@@ -19,9 +21,20 @@
 }
 
 - (void)onModuleInit {
-    [self setFlutterPageBuilder:^(NSString *entrypoint) {
-        return [[CustomFlutterViewController alloc] initWithEntrypoint:entrypoint];
-    }];
+}
+
+- (void)onJsonSerializerRegister {
+    [self registerJsonSerializer:^NSDictionary *_Nullable (id params) {
+        return [params toJson];
+    } forClass:THRPeople.class];
+}
+
+- (void)onJsonDeserializerRegister {
+    [self registerJsonDeserializer:^id _Nullable(NSDictionary *params) {
+        return [THRPeople fromJson:params];
+    } forClass:THRPeople.class];
 }
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/example/ios/Runner/SwiftModule.swift
+++ b/example/ios/Runner/SwiftModule.swift
@@ -3,7 +3,7 @@
 //  Runner
 //
 //  Created by foxsofter on 2020/10/30.
-//  Copyright © 2020 The Chromium Authors. All rights reserved.
+//  Copyright © 2020 foxsofter. All rights reserved.
 //
 
 import Foundation
@@ -20,15 +20,29 @@ class SwiftModule: ThrioModule {
     override func onModuleInit() {
     }
 
-    override func onPageRegister() {
-        _ = register(SwiftPageObserver())
-        _ = register(SwiftRouteObserver())
-        _ = register({ (params) -> UIViewController? in
+    override func onPageBuilderRegister() {
+        _ = register({ (_) -> UIViewController? in
             if #available(iOS 13.0, *) {
                 return UIHostingController(rootView: Page5View())
             } else {
                 return UIViewController()
             }
         }, forUrl: "/biz1/swift1")
+    }
+
+    override func onPageObserverRegister() {
+        _ = register(SwiftPageObserver())
+    }
+
+    override func onRouteObserverRegister() {
+        _ = register(SwiftRouteObserver())
+    }
+    
+    override func onJsonSerializerRegister() {
+        
+    }
+    
+    override func onJsonDeserializerRegister() {
+        
     }
 }

--- a/example/ios/Runner/THRPeople.h
+++ b/example/ios/Runner/THRPeople.h
@@ -1,0 +1,26 @@
+//
+//  THRPeople.h
+//  Runner
+//
+//  Created by foxsofter on 2020/12/6.
+//  Copyright © 2020 foxsofter. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface THRPeople : NSObject
+
++ (_Nullable instancetype)fromJson:(NSDictionary *_Nullable)json;
+- (instancetype)initWithJson:(NSDictionary *)json;
+
+- (NSDictionary *_Nullable)toJson;
+
+@property (nonatomic, copy)   NSString *name;
+@property (nonatomic, strong) NSNumber *age;
+@property (nonatomic, copy)   NSString *sex;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/example/ios/Runner/THRPeople.m
+++ b/example/ios/Runner/THRPeople.m
@@ -1,0 +1,51 @@
+//
+//  THRPeople.m
+//  Runner
+//
+//  Created by foxsofter on 2020/12/6.
+//  Copyright © 2020 foxsofter. All rights reserved.
+//
+
+#import "THRPeople.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation THRPeople
+
++ (_Nullable instancetype)fromJson:(NSDictionary *_Nullable)json {
+    return json ? [[THRPeople alloc] initWithJson:json] : nil;
+}
+
+- (instancetype)initWithJson:(NSDictionary *)json {
+    if (self = [super init]) {
+        [self setValuesForKeysWithDictionary:json];
+    }
+    return self;
+}
+
+- (NSDictionary *_Nullable)toJson {
+    return [self dictionaryWithValuesForKeys:THRPeople.properties.allValues];
+}
+
++ (NSDictionary<NSString *, NSString *> *)properties {
+    static NSDictionary<NSString *, NSString *> *properties;
+    return properties = properties ? properties : @{
+        @"name": @"name",
+        @"age": @"age",
+        @"sex": @"sex",
+    };
+}
+
+- (void)setValue:(nullable id)value forKey:(NSString *)key {
+    id resolved = THRPeople.properties[key];
+    if (resolved) [super setValue:value forKey:resolved];
+}
+
+- (void)setNilValueForKey:(NSString *)key {
+    id resolved = THRPeople.properties[key];
+    if (resolved) [super setValue:@0 forKey:resolved];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/example/ios/Runner/ThrioViewController.h
+++ b/example/ios/Runner/ThrioViewController.h
@@ -3,7 +3,7 @@
 //  Runner
 //
 //  Created by foxsofter on 2019/12/25.
-//  Copyright © 2019 The Chromium Authors. All rights reserved.
+//  Copyright © 2019 foxsofter. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/example/ios/Runner/ThrioViewController.m
+++ b/example/ios/Runner/ThrioViewController.m
@@ -3,12 +3,13 @@
 //  Runner
 //
 //  Created by foxsofter on 2019/12/25.
-//  Copyright © 2019 The Chromium Authors. All rights reserved.
+//  Copyright © 2019 foxsofter. All rights reserved.
 //
 
 #import "ThrioViewController.h"
 #import <Flutter/Flutter.h>
 #import <thrio/Thrio.h>
+#import "THRPeople.h"
 
 @interface ThrioViewController () <NavigatorPageNotifyProtocol>
 
@@ -19,7 +20,14 @@
 @implementation ThrioViewController
 
 - (IBAction)pushFlutterPage:(id)sender {
-    [ThrioNavigator pushUrl:@"/biz1/flutter1" params:@1];
+    THRPeople *people = [THRPeople fromJson:@{
+        @"name": @"foxsofter",
+        @"age": @100,
+        @"sex": @"x"
+    }];
+    [ThrioNavigator pushUrl:@"/biz1/flutter1" params:people poppedResult:^(id _Nullable params) {
+        ThrioLogV(@"/biz1/flutter1 popped: %@", params);
+    }];
 }
 
 - (IBAction)popFlutter1:(id)sender {
@@ -54,11 +62,23 @@
 }
 
 - (IBAction)pop:(id)sender {
-    [ThrioNavigator pop];
+    THRPeople *people = [THRPeople fromJson:@{
+        @"name": @"foxsofter",
+        @"age": @100,
+        @"sex": @"x"
+    }];
+
+    [ThrioNavigator popParams:people];
 }
 
 - (IBAction)notifyAll:(id)sender {
-    [ThrioNavigator notifyWithName:@"all_page_notify"];
+    THRPeople *people = [THRPeople fromJson:@{
+        @"name": @"notify",
+        @"age": @100,
+        @"sex": @"x"
+    }];
+
+    [ThrioNavigator notifyWithName:@"all_page_notify" params:people];
 }
 
 - (IBAction)pushNative1WithNvc:(id)sender {

--- a/example/ios/Runner/ThrioViewController2.h
+++ b/example/ios/Runner/ThrioViewController2.h
@@ -3,7 +3,7 @@
 //  Runner
 //
 //  Created by foxsofter on 2019/12/25.
-//  Copyright © 2019 The Chromium Authors. All rights reserved.
+//  Copyright © 2019 foxsofter. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/example/ios/Runner/ThrioViewController2.m
+++ b/example/ios/Runner/ThrioViewController2.m
@@ -3,7 +3,7 @@
 //  Runner
 //
 //  Created by foxsofter on 2019/12/25.
-//  Copyright © 2019 The Chromium Authors. All rights reserved.
+//  Copyright © 2019 foxsofter. All rights reserved.
 //
 
 #import "ThrioViewController2.h"

--- a/example/ios/thrio_exampleTests/Registry/ThrioRegistryMapTests.m
+++ b/example/ios/thrio_exampleTests/Registry/ThrioRegistryMapTests.m
@@ -3,7 +3,7 @@
 //  thrio_exampleTests
 //
 //  Created by foxsofter on 2019/12/25.
-//  Copyright © 2019 The Chromium Authors. All rights reserved.
+//  Copyright © 2019 foxsofter. All rights reserved.
 //
 
 #import <XCTest/XCTest.h>

--- a/example/ios/thrio_exampleTests/Registry/ThrioRegistrySetTests.m
+++ b/example/ios/thrio_exampleTests/Registry/ThrioRegistrySetTests.m
@@ -3,7 +3,7 @@
 //  thrio_exampleTests
 //
 //  Created by foxsofter on 2019/12/25.
-//  Copyright © 2019 The Chromium Authors. All rights reserved.
+//  Copyright © 2019 foxsofter. All rights reserved.
 //
 
 #import <XCTest/XCTest.h>

--- a/example/ios/thrio_exampleTests/thrio_exampleTests.m
+++ b/example/ios/thrio_exampleTests/thrio_exampleTests.m
@@ -3,7 +3,7 @@
 //  thrio_exampleTests
 //
 //  Created by foxsofter on 2019/12/25.
-//  Copyright © 2019 The Chromium Authors. All rights reserved.
+//  Copyright © 2019 foxsofter. All rights reserved.
 //
 
 #import <XCTest/XCTest.h>

--- a/example/lib/src/sample/module1/page1.dart
+++ b/example/lib/src/sample/module1/page1.dart
@@ -39,185 +39,189 @@ class _Page1State extends State<Page1> {
 
   @override
   Widget build(BuildContext context) => NavigatorPageNotify(
-      name: 'page1Notify',
+      name: 'all_page_notify',
       onPageNotify: (params) =>
-          ThrioLogger.v('flutter1 receive notify:$params'),
-      child: Scaffold(
-          appBar: PreferredSize(
-              preferredSize: Platform.isIOS
-                  ? const Size.fromHeight(44)
-                  : const Size.fromHeight(56),
-              child: AppBar(
-                brightness: Brightness.light,
-                backgroundColor: Colors.blue,
-                title: const Text('thrio_example',
-                    style: TextStyle(color: Colors.black)),
-                leading: const IconButton(
-                  color: Colors.black,
-                  tooltip: 'back',
-                  icon: Icon(Icons.arrow_back_ios),
-                  onPressed: ThrioNavigator.pop,
+          ThrioLogger.v('flutter1 receive all page notify:${params()}'),
+      child: NavigatorPageNotify(
+          name: 'page1Notify',
+          onPageNotify: (params) =>
+              ThrioLogger.v('flutter1 receive notify:${params()}'),
+          child: Scaffold(
+              appBar: PreferredSize(
+                  preferredSize: Platform.isIOS
+                      ? const Size.fromHeight(44)
+                      : const Size.fromHeight(56),
+                  child: AppBar(
+                    brightness: Brightness.light,
+                    backgroundColor: Colors.blue,
+                    title: const Text('thrio_example',
+                        style: TextStyle(color: Colors.black)),
+                    leading: const IconButton(
+                      color: Colors.black,
+                      tooltip: 'back',
+                      icon: Icon(Icons.arrow_back_ios),
+                      onPressed: ThrioNavigator.pop,
+                    ),
+                  )),
+              body: SingleChildScrollView(
+                child: Container(
+                  margin: const EdgeInsets.all(24),
+                  child: Column(children: <Widget>[
+                    Container(
+                      margin: const EdgeInsets.only(top: 10, bottom: 20),
+                      alignment: AlignmentDirectional.center,
+                      child: Text(
+                        'flutter1: index is ${widget.index}',
+                        style:
+                            const TextStyle(fontSize: 28, color: Colors.blue),
+                      ),
+                    ),
+                    Container(
+                        height: 25,
+                        width: 100,
+                        child: TextField(
+                            controller: _inputController,
+                            textInputAction: TextInputAction.search,
+                            // onSubmitted: onSubmitted,
+                            decoration: const InputDecoration(
+                              hintText: 'hintText',
+                              contentPadding: EdgeInsets.only(bottom: 12),
+                              border: InputBorder.none,
+                            ),
+                            onChanged: print)),
+                    InkWell(
+                      onTap: () => ThrioNavigator.push(
+                        url: '/biz1/flutter1',
+                        params: People(name: 'foxsofter', age: 100, sex: '男性'),
+                        poppedResult: (params) =>
+                            ThrioLogger.v('/biz1/flutter1 popped:$params'),
+                      ),
+                      child: Container(
+                          padding: const EdgeInsets.all(8),
+                          margin: const EdgeInsets.all(8),
+                          color: Colors.yellow,
+                          child: const Text(
+                            'push flutter1',
+                            style: TextStyle(fontSize: 22, color: Colors.black),
+                          )),
+                    ),
+                    InkWell(
+                      onTap: () => ThrioNavigator.remove(url: '/biz1/flutter1'),
+                      child: Container(
+                          padding: const EdgeInsets.all(8),
+                          margin: const EdgeInsets.all(8),
+                          color: Colors.yellow,
+                          child: const Text(
+                            'remove flutter1',
+                            style: TextStyle(fontSize: 22, color: Colors.black),
+                          )),
+                    ),
+                    InkWell(
+                      onTap: () => ThrioNavigator.push(
+                        url: '/biz2/flutter2',
+                        params: People(name: '大宝剑', age: 0, sex: 'x'),
+                        poppedResult: (params) => ThrioLogger.v(
+                            '/biz1/flutter1 poppedResult call popped:${params()}'),
+                      ),
+                      child: Container(
+                          padding: const EdgeInsets.all(8),
+                          margin: const EdgeInsets.all(8),
+                          color: Colors.yellow,
+                          child: const Text(
+                            'push flutter2',
+                            style: TextStyle(fontSize: 22, color: Colors.black),
+                          )),
+                    ),
+                    InkWell(
+                      onTap: () => ThrioNavigator.pop(
+                          params: People(name: '大宝剑', age: 0, sex: 'x')),
+                      child: Container(
+                          padding: const EdgeInsets.all(8),
+                          margin: const EdgeInsets.all(8),
+                          color: Colors.yellow,
+                          child: const Text(
+                            'pop',
+                            style: TextStyle(fontSize: 22, color: Colors.black),
+                          )),
+                    ),
+                    InkWell(
+                      onTap: () => ThrioNavigator.push(
+                        url: '/biz1/native1',
+                        params: People(name: '大宝剑', age: 10, sex: 'x'),
+                        poppedResult: (params) => ThrioLogger.v(
+                            '/biz1/native1 poppedResult call params:${params()}'),
+                      ),
+                      child: Container(
+                          padding: const EdgeInsets.all(8),
+                          margin: const EdgeInsets.all(8),
+                          color: Colors.grey,
+                          child: const Text(
+                            'push native1',
+                            style: TextStyle(fontSize: 22, color: Colors.black),
+                          )),
+                    ),
+                    InkWell(
+                      onTap: () => ThrioNavigator.notify(
+                        url: '/biz1/native1',
+                        name: 'aaa',
+                        params: {
+                          '1': {'2': '3'}
+                        },
+                      ),
+                      child: Container(
+                          padding: const EdgeInsets.all(8),
+                          margin: const EdgeInsets.all(8),
+                          color: Colors.grey,
+                          child: const Text(
+                            'notify native1',
+                            style: TextStyle(fontSize: 22, color: Colors.black),
+                          )),
+                    ),
+                    InkWell(
+                      onTap: () => ThrioNavigator.remove(url: '/biz1/native1'),
+                      child: Container(
+                          padding: const EdgeInsets.all(8),
+                          margin: const EdgeInsets.all(8),
+                          color: Colors.grey,
+                          child: const Text(
+                            'remove native1',
+                            style: TextStyle(fontSize: 22, color: Colors.black),
+                          )),
+                    ),
+                    InkWell(
+                      onTap: () => ThrioNavigator.push(url: '/biz1/swift1'),
+                      child: Container(
+                          padding: const EdgeInsets.all(8),
+                          margin: const EdgeInsets.all(8),
+                          color: Colors.grey,
+                          child: const Text(
+                            'push swift1',
+                            style: TextStyle(fontSize: 22, color: Colors.black),
+                          )),
+                    ),
+                    NavigatorPageLifecycle(
+                        willAppear: (settings) {
+                          ThrioLogger.v('lifecycle willAppear -> $settings');
+                        },
+                        didAppear: (settings) {
+                          ThrioLogger.v('lifecycle didAppear -> $settings');
+                        },
+                        willDisappear: (settings) {
+                          ThrioLogger.v('lifecycle willDisappear -> $settings');
+                        },
+                        didDisappear: (settings) {
+                          ThrioLogger.v('lifecycle didDisappear -> $settings');
+                        },
+                        child: Container(
+                            padding: const EdgeInsets.all(8),
+                            margin: const EdgeInsets.all(8),
+                            color: Colors.grey,
+                            child: const Text(
+                              '',
+                              style:
+                                  TextStyle(fontSize: 22, color: Colors.black),
+                            )))
+                  ]),
                 ),
-              )),
-          body: SingleChildScrollView(
-            child: Container(
-              margin: const EdgeInsets.all(24),
-              child: Column(children: <Widget>[
-                Container(
-                  margin: const EdgeInsets.only(top: 10, bottom: 20),
-                  alignment: AlignmentDirectional.center,
-                  child: Text(
-                    'flutter1: index is ${widget.index}',
-                    style: const TextStyle(fontSize: 28, color: Colors.blue),
-                  ),
-                ),
-                Container(
-                    height: 25,
-                    width: 100,
-                    child: TextField(
-                        controller: _inputController,
-                        textInputAction: TextInputAction.search,
-                        // onSubmitted: onSubmitted,
-                        decoration: const InputDecoration(
-                          hintText: 'hintText',
-                          contentPadding: EdgeInsets.only(bottom: 12),
-                          border: InputBorder.none,
-                        ),
-                        onChanged: print)),
-                InkWell(
-                  onTap: () => ThrioNavigator.push(
-                    url: '/biz1/flutter1',
-                    params: People(name: 'foxsofter', age: 100, sex: '男性'),
-                    poppedResult: (params) =>
-                        ThrioLogger.v('/biz1/flutter1 popped:$params'),
-                  ),
-                  child: Container(
-                      padding: const EdgeInsets.all(8),
-                      margin: const EdgeInsets.all(8),
-                      color: Colors.yellow,
-                      child: const Text(
-                        'push flutter1',
-                        style: TextStyle(fontSize: 22, color: Colors.black),
-                      )),
-                ),
-                InkWell(
-                  onTap: () => ThrioNavigator.remove(url: '/biz1/flutter1'),
-                  child: Container(
-                      padding: const EdgeInsets.all(8),
-                      margin: const EdgeInsets.all(8),
-                      color: Colors.yellow,
-                      child: const Text(
-                        'remove flutter1',
-                        style: TextStyle(fontSize: 22, color: Colors.black),
-                      )),
-                ),
-                InkWell(
-                  onTap: () => ThrioNavigator.push(
-                    url: '/biz2/flutter2',
-                    params: People(name: '大宝剑', age: 0, sex: 'x'),
-                    poppedResult: (params) => ThrioLogger.v(
-                        '/biz1/flutter1 poppedResult call popped:${params()}'),
-                  ),
-                  child: Container(
-                      padding: const EdgeInsets.all(8),
-                      margin: const EdgeInsets.all(8),
-                      color: Colors.yellow,
-                      child: const Text(
-                        'push flutter2',
-                        style: TextStyle(fontSize: 22, color: Colors.black),
-                      )),
-                ),
-                InkWell(
-                  onTap: () => ThrioNavigator.pop(
-                      params: People(name: '大宝剑', age: 0, sex: 'x')),
-                  child: Container(
-                      padding: const EdgeInsets.all(8),
-                      margin: const EdgeInsets.all(8),
-                      color: Colors.yellow,
-                      child: const Text(
-                        'pop',
-                        style: TextStyle(fontSize: 22, color: Colors.black),
-                      )),
-                ),
-                InkWell(
-                  onTap: () => ThrioNavigator.push(
-                    url: '/biz1/native1',
-                    params: {
-                      '1': {'2': '3'}
-                    },
-                    poppedResult: (params) => ThrioLogger.v(
-                        '/biz1/native1 poppedResult call params:$params'),
-                  ),
-                  child: Container(
-                      padding: const EdgeInsets.all(8),
-                      margin: const EdgeInsets.all(8),
-                      color: Colors.grey,
-                      child: const Text(
-                        'push native1',
-                        style: TextStyle(fontSize: 22, color: Colors.black),
-                      )),
-                ),
-                InkWell(
-                  onTap: () => ThrioNavigator.notify(
-                    url: '/biz1/native1',
-                    name: 'aaa',
-                    params: {
-                      '1': {'2': '3'}
-                    },
-                  ),
-                  child: Container(
-                      padding: const EdgeInsets.all(8),
-                      margin: const EdgeInsets.all(8),
-                      color: Colors.grey,
-                      child: const Text(
-                        'notify native1',
-                        style: TextStyle(fontSize: 22, color: Colors.black),
-                      )),
-                ),
-                InkWell(
-                  onTap: () => ThrioNavigator.remove(url: '/biz1/native1'),
-                  child: Container(
-                      padding: const EdgeInsets.all(8),
-                      margin: const EdgeInsets.all(8),
-                      color: Colors.grey,
-                      child: const Text(
-                        'remove native1',
-                        style: TextStyle(fontSize: 22, color: Colors.black),
-                      )),
-                ),
-                InkWell(
-                  onTap: () => ThrioNavigator.push(url: '/biz1/swift1'),
-                  child: Container(
-                      padding: const EdgeInsets.all(8),
-                      margin: const EdgeInsets.all(8),
-                      color: Colors.grey,
-                      child: const Text(
-                        'push swift1',
-                        style: TextStyle(fontSize: 22, color: Colors.black),
-                      )),
-                ),
-                NavigatorPageLifecycle(
-                    willAppear: (settings) {
-                      ThrioLogger.v('lifecycle willAppear -> $settings');
-                    },
-                    didAppear: (settings) {
-                      ThrioLogger.v('lifecycle didAppear -> $settings');
-                    },
-                    willDisappear: (settings) {
-                      ThrioLogger.v('lifecycle willDisappear -> $settings');
-                    },
-                    didDisappear: (settings) {
-                      ThrioLogger.v('lifecycle didDisappear -> $settings');
-                    },
-                    child: Container(
-                        padding: const EdgeInsets.all(8),
-                        margin: const EdgeInsets.all(8),
-                        color: Colors.grey,
-                        child: const Text(
-                          '',
-                          style: TextStyle(fontSize: 22, color: Colors.black),
-                        )))
-              ]),
-            ),
-          )));
+              ))));
 }

--- a/example/lib/src/sample/module1/page1.dart
+++ b/example/lib/src/sample/module1/page1.dart
@@ -41,11 +41,11 @@ class _Page1State extends State<Page1> {
   Widget build(BuildContext context) => NavigatorPageNotify(
       name: 'all_page_notify',
       onPageNotify: (params) =>
-          ThrioLogger.v('flutter1 receive all page notify:${params()}'),
+          ThrioLogger.v('flutter1 receive all page notify:$params'),
       child: NavigatorPageNotify(
           name: 'page1Notify',
           onPageNotify: (params) =>
-              ThrioLogger.v('flutter1 receive notify:${params()}'),
+              ThrioLogger.v('flutter1 receive notify:$params'),
           child: Scaffold(
               appBar: PreferredSize(
                   preferredSize: Platform.isIOS
@@ -121,7 +121,7 @@ class _Page1State extends State<Page1> {
                         url: '/biz2/flutter2',
                         params: People(name: '大宝剑', age: 0, sex: 'x'),
                         poppedResult: (params) => ThrioLogger.v(
-                            '/biz1/flutter1 poppedResult call popped:${params()}'),
+                            '/biz1/flutter1 poppedResult call popped:$params'),
                       ),
                       child: Container(
                           padding: const EdgeInsets.all(8),
@@ -149,7 +149,7 @@ class _Page1State extends State<Page1> {
                         url: '/biz1/native1',
                         params: People(name: '大宝剑', age: 10, sex: 'x'),
                         poppedResult: (params) => ThrioLogger.v(
-                            '/biz1/native1 poppedResult call params:${params()}'),
+                            '/biz1/native1 poppedResult call params:$params'),
                       ),
                       child: Container(
                           padding: const EdgeInsets.all(8),

--- a/example/lib/src/sample/module1/page2.dart
+++ b/example/lib/src/sample/module1/page2.dart
@@ -36,7 +36,7 @@ class _Page2State extends State<Page2> {
   Widget build(BuildContext context) => NavigatorPageNotify(
       name: 'page2Notify',
       onPageNotify: (params) =>
-          ThrioLogger.v('flutter2 receive notify:${params()}'),
+          ThrioLogger.v('flutter2 receive notify:$params'),
       child: Scaffold(
           appBar: AppBar(
             brightness: Brightness.light,

--- a/ios/Classes/Module/ThrioModule.m
+++ b/ios/Classes/Module/ThrioModule.m
@@ -20,11 +20,18 @@
 // IN THE SOFTWARE.
 
 #import "NavigatorFlutterEngineFactory.h"
+#import "NavigatorPageObserverProtocol.h"
+#import "NavigatorRouteObserverProtocol.h"
 #import "ThrioModule.h"
 #import "ThrioNavigator+Internal.h"
 #import "ThrioNavigator+PageBuilders.h"
 #import "ThrioNavigator+PageObservers.h"
 #import "ThrioNavigator+RouteObservers.h"
+#import "ThrioModuleJsonDeserializer.h"
+#import "ThrioModuleJsonSerializer.h"
+#import "ThrioModulePageBuilder.h"
+#import "ThrioModulePageObserver.h"
+#import "ThrioModuleRouteObserver.h"
 
 @implementation ThrioModule
 
@@ -57,12 +64,6 @@ static NSMutableDictionary *modules;
 - (void)initModule {
     NSArray *values = modules.allValues;
     for (ThrioModule *module in values) {
-        if ([module respondsToSelector:@selector(onPageRegister)]) {
-            [module onPageRegister];
-        }
-    }
-
-    for (ThrioModule *module in values) {
         if ([module respondsToSelector:@selector(onModuleInit)]) {
             [module onModuleInit];
         }
@@ -74,6 +75,28 @@ static NSMutableDictionary *modules;
             }
         }
     });
+    for (ThrioModule *module in values) {
+        if ([module respondsToSelector:@selector(onPageBuilderRegister)]) {
+            [module onPageBuilderRegister];
+        }
+    }
+    for (ThrioModule *module in values) {
+        if ([module respondsToSelector:@selector(onPageObserverRegister)]) {
+            [module onPageObserverRegister];
+        }
+        if ([module respondsToSelector:@selector(onRouteObserverRegister)]) {
+            [module onRouteObserverRegister];
+        }
+    }
+    for (ThrioModule *module in values) {
+        if ([module respondsToSelector:@selector(onJsonSerializerRegister)]) {
+            [module onJsonSerializerRegister];
+        }
+        if ([module respondsToSelector:@selector(onJsonDeserializerRegister)]) {
+            [module onJsonDeserializerRegister];
+        }
+    }
+
     // 单引擎模式下，提前启动，默认 `entrypoint` 为 main
     if (!NavigatorFlutterEngineFactory.shared.multiEngineEnabled) {
         [NavigatorFlutterEngineFactory.shared startupWithEntrypoint:@"main" readyBlock:nil];
@@ -81,9 +104,6 @@ static NSMutableDictionary *modules;
 }
 
 - (void)onModuleRegister {
-}
-
-- (void)onPageRegister {
 }
 
 - (void)onModuleInit {

--- a/ios/Classes/Module/ThrioModuleJsonDeserializer.h
+++ b/ios/Classes/Module/ThrioModuleJsonDeserializer.h
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019 Hellobike Group
+// Copyright (c) 2020 foxsofter
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -24,46 +24,22 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface ThrioModule : NSObject
+@protocol ThrioModuleJsonDeserializer <NSObject>
 
-/// Module entrypoint method.
-///
-+ (void)init:(ThrioModule *)rootModule;
-
-+ (void)init:(ThrioModule *)rootModule multiEngineEnabled:(BOOL)enabled;
-
-/// A function for registering a module.
-///
-/// Should be called in `onModuleRegister`.
-///
-- (void)registerModule:(ThrioModule *)module;
-
-/// A function for module initialization that will call  the `onPageRegister`, `onModuleInit` and `onModuleAsyncInit`
-/// methods of all modules.
-///
-/// Should only be called once when the app startups.
-///
-- (void)initModule;
-
-/// A function for registering submodules.
-///
-- (void)onModuleRegister;
-
-/// A function for module initialization.
-///
-- (void)onModuleInit;
-
-/// A function for module asynchronous initialization.
-///
-- (void)onModuleAsyncInit;
-
-/// Startup the flutter engine with `entrypoint`.
-///
-/// Should be called in `onModuleAsyncInit`. Subsequent calls will return immediately if the entrypoint is the same.
+/// Register json deserializer for class.
 ///
 /// Do not override this method.
 ///
-- (void)startupFlutterEngineWithEntrypoint:(NSString *)entrypoint;
+- (ThrioVoidCallback)registerJsonDeserializer:(ThrioJsonDeserializer)deserializer
+                                     forClass:(Class)clazz;
+
+@end
+
+@class ThrioModule;
+
+@interface ThrioModule (JsonDeserializer) <ThrioModuleJsonDeserializer>
+
+- (void)onJsonDeserializerRegister;
 
 @end
 

--- a/ios/Classes/Module/ThrioModuleJsonDeserializer.m
+++ b/ios/Classes/Module/ThrioModuleJsonDeserializer.m
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019 Hellobike Group
+// Copyright (c) 2020 foxsofter
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -19,51 +19,22 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 
-#import <Foundation/Foundation.h>
-#import "ThrioTypes.h"
+#import "ThrioModule.h"
+#import "ThrioModuleJsonDeserializer.h"
+#import "ThrioNavigator+JsonDeserializers.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface ThrioModule : NSObject
+@implementation ThrioModule (JsonDeserializer)
 
-/// Module entrypoint method.
-///
-+ (void)init:(ThrioModule *)rootModule;
+- (void)onJsonDeserializerRegister {
+}
 
-+ (void)init:(ThrioModule *)rootModule multiEngineEnabled:(BOOL)enabled;
-
-/// A function for registering a module.
-///
-/// Should be called in `onModuleRegister`.
-///
-- (void)registerModule:(ThrioModule *)module;
-
-/// A function for module initialization that will call  the `onPageRegister`, `onModuleInit` and `onModuleAsyncInit`
-/// methods of all modules.
-///
-/// Should only be called once when the app startups.
-///
-- (void)initModule;
-
-/// A function for registering submodules.
-///
-- (void)onModuleRegister;
-
-/// A function for module initialization.
-///
-- (void)onModuleInit;
-
-/// A function for module asynchronous initialization.
-///
-- (void)onModuleAsyncInit;
-
-/// Startup the flutter engine with `entrypoint`.
-///
-/// Should be called in `onModuleAsyncInit`. Subsequent calls will return immediately if the entrypoint is the same.
-///
-/// Do not override this method.
-///
-- (void)startupFlutterEngineWithEntrypoint:(NSString *)entrypoint;
+- (ThrioVoidCallback)registerJsonDeserializer:(id)deserializer
+                                     forClass:(id)clazz {
+    return [ThrioNavigator.jsonDeserializers registry:NSStringFromClass(clazz)
+                                                value:deserializer];
+}
 
 @end
 

--- a/ios/Classes/Module/ThrioModuleJsonSerializer.h
+++ b/ios/Classes/Module/ThrioModuleJsonSerializer.h
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019 Hellobike Group
+// Copyright (c) 2020 foxsofter
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -24,46 +24,22 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface ThrioModule : NSObject
+@protocol ThrioModuleJsonSerializer <NSObject>
 
-/// Module entrypoint method.
-///
-+ (void)init:(ThrioModule *)rootModule;
-
-+ (void)init:(ThrioModule *)rootModule multiEngineEnabled:(BOOL)enabled;
-
-/// A function for registering a module.
-///
-/// Should be called in `onModuleRegister`.
-///
-- (void)registerModule:(ThrioModule *)module;
-
-/// A function for module initialization that will call  the `onPageRegister`, `onModuleInit` and `onModuleAsyncInit`
-/// methods of all modules.
-///
-/// Should only be called once when the app startups.
-///
-- (void)initModule;
-
-/// A function for registering submodules.
-///
-- (void)onModuleRegister;
-
-/// A function for module initialization.
-///
-- (void)onModuleInit;
-
-/// A function for module asynchronous initialization.
-///
-- (void)onModuleAsyncInit;
-
-/// Startup the flutter engine with `entrypoint`.
-///
-/// Should be called in `onModuleAsyncInit`. Subsequent calls will return immediately if the entrypoint is the same.
+/// Register json serializer for class.
 ///
 /// Do not override this method.
 ///
-- (void)startupFlutterEngineWithEntrypoint:(NSString *)entrypoint;
+- (ThrioVoidCallback)registerJsonSerializer:(ThrioJsonSerializer)serializer
+                                   forClass:(Class)clazz;
+
+@end
+
+@class ThrioModule;
+
+@interface ThrioModule (JsonSerializer) <ThrioModuleJsonSerializer>
+
+- (void)onJsonSerializerRegister;
 
 @end
 

--- a/ios/Classes/Module/ThrioModuleJsonSerializer.m
+++ b/ios/Classes/Module/ThrioModuleJsonSerializer.m
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019 Hellobike Group
+// Copyright (c) 2020 foxsofter
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -19,51 +19,22 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 
-#import <Foundation/Foundation.h>
-#import "ThrioTypes.h"
+#import "ThrioModule.h"
+#import "ThrioModuleJsonSerializer.h"
+#import "ThrioNavigator+JsonSerializers.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface ThrioModule : NSObject
+@implementation ThrioModule (JsonSerializer)
 
-/// Module entrypoint method.
-///
-+ (void)init:(ThrioModule *)rootModule;
+- (void)onJsonSerializerRegister {
+}
 
-+ (void)init:(ThrioModule *)rootModule multiEngineEnabled:(BOOL)enabled;
-
-/// A function for registering a module.
-///
-/// Should be called in `onModuleRegister`.
-///
-- (void)registerModule:(ThrioModule *)module;
-
-/// A function for module initialization that will call  the `onPageRegister`, `onModuleInit` and `onModuleAsyncInit`
-/// methods of all modules.
-///
-/// Should only be called once when the app startups.
-///
-- (void)initModule;
-
-/// A function for registering submodules.
-///
-- (void)onModuleRegister;
-
-/// A function for module initialization.
-///
-- (void)onModuleInit;
-
-/// A function for module asynchronous initialization.
-///
-- (void)onModuleAsyncInit;
-
-/// Startup the flutter engine with `entrypoint`.
-///
-/// Should be called in `onModuleAsyncInit`. Subsequent calls will return immediately if the entrypoint is the same.
-///
-/// Do not override this method.
-///
-- (void)startupFlutterEngineWithEntrypoint:(NSString *)entrypoint;
+- (ThrioVoidCallback)registerJsonSerializer:(id)serializer
+                                   forClass:(id)clazz {
+    return [ThrioNavigator.jsonSerializers registry:NSStringFromClass(clazz)
+                                              value:serializer];
+}
 
 @end
 

--- a/ios/Classes/Module/ThrioModulePageBuilder.h
+++ b/ios/Classes/Module/ThrioModulePageBuilder.h
@@ -29,7 +29,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface ThrioModulePageBuilder : NSObject<ThrioModulePageBuilder>
+@class ThrioModule;
+
+@interface ThrioModule (PageBuilder) <ThrioModulePageBuilder>
+
+/// A function for register a `PageBuilder` .
+///
+- (void)onPageBuilderRegister;
 
 @end
 

--- a/ios/Classes/Module/ThrioModulePageBuilder.m
+++ b/ios/Classes/Module/ThrioModulePageBuilder.m
@@ -5,10 +5,11 @@
 //  Created by foxsofter on 2020/10/2.
 //
 
+#import "ThrioModule.h"
 #import "ThrioModulePageBuilder.h"
 #import "ThrioNavigator+PageBuilders.h"
 
-@implementation ThrioModulePageBuilder
+@implementation ThrioModule (PageBuilder)
 
 - (ThrioVoidCallback)registerPageBuilder:(NavigatorPageBuilder)builder
                                   forUrl:(NSString *)url {
@@ -17,6 +18,9 @@
 
 - (void)setFlutterPageBuilder:(NavigatorFlutterPageBuilder)builder {
     ThrioNavigator.flutterPageBuilder = builder;
+}
+
+- (void)onPageBuilderRegister {
 }
 
 @end

--- a/ios/Classes/Module/ThrioModulePageObserver.h
+++ b/ios/Classes/Module/ThrioModulePageObserver.h
@@ -8,7 +8,6 @@
 #import <Foundation/Foundation.h>
 #import "ThrioTypes.h"
 #import "NavigatorPageObserverProtocol.h"
-#import "ThrioModule.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -22,7 +21,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@class ThrioModule;
+
 @interface ThrioModule (PageObserver) <ThrioModulePageObserver>
+
+- (void)onPageObserverRegister;
 
 @end
 

--- a/ios/Classes/Module/ThrioModuleRouteObserver.h
+++ b/ios/Classes/Module/ThrioModuleRouteObserver.h
@@ -21,7 +21,6 @@
 
 #import <Foundation/Foundation.h>
 #import "ThrioTypes.h"
-#import "ThrioModule.h"
 #import "NavigatorRouteObserverProtocol.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -39,6 +38,8 @@ NS_ASSUME_NONNULL_BEGIN
 @class ThrioModule;
 
 @interface ThrioModule (RouteObserver) <ThrioModuleRouteObserver>
+
+- (void)onRouteObserverRegister;
 
 @end
 

--- a/ios/Classes/Module/ThrioModuleRouteObserver.m
+++ b/ios/Classes/Module/ThrioModuleRouteObserver.m
@@ -19,6 +19,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 
+#import "ThrioModule.h"
 #import "ThrioModuleRouteObserver.h"
 #import "ThrioNavigator+RouteObservers.h"
 
@@ -28,6 +29,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (ThrioVoidCallback)registerRouteObserver:(id<NavigatorRouteObserverProtocol>)routeObserver {
     return [ThrioNavigator.routeObservers.observers registry:routeObserver];
+}
+
+- (void)onRouteObserverRegister {
+    
 }
 
 @end

--- a/ios/Classes/Navigator/NavigatorRouteReceiveChannel.m
+++ b/ios/Classes/Navigator/NavigatorRouteReceiveChannel.m
@@ -95,10 +95,7 @@ NS_ASSUME_NONNULL_BEGIN
                     }
                     return;
                 }
-                id params =
-                    [arguments[@"params"] isKindOfClass:NSNull.class]
-            ? nil
-            : arguments[@"params"];
+                id params = [arguments[@"params"] isKindOfClass:NSNull.class] ? nil : arguments[@"params"];
                 BOOL animated = [arguments[@"animated"] boolValue];
                 NavigatorVerbose(@"on push: %@", url);
                 __strong typeof(weakself) strongSelf = weakself;

--- a/ios/Classes/Navigator/NavigatorRouteReceiveChannel.m
+++ b/ios/Classes/Navigator/NavigatorRouteReceiveChannel.m
@@ -50,8 +50,12 @@ NS_ASSUME_NONNULL_BEGIN
         [self _onPop];
         [self _onPopTo];
         [self _onRemove];
+        
         [self _onLastIndex];
         [self _onGetAllIndexes];
+        [self _onLastRoute];
+        [self _onGetAllRoutes];
+
         [self _onSetPopDisabled];
         [self _onHotRestart];
         [self _onRegisterUrls];
@@ -212,14 +216,14 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)_onLastIndex {
-    [_channel registryMethod:@"lastRoute"
+    [_channel registryMethod:@"lastIndex"
                      handler:
      ^void (NSDictionary<NSString *, id> *arguments,
             ThrioIdCallback _Nullable result) {
                 if (result) {
-                    NSString *url = arguments[@"url"];
+                    NSString *url = [arguments[@"url"] isKindOfClass:NSNull.class] ? nil : arguments[@"url"];
                     NavigatorPageRoute *lastRoute = nil;
-                    if (url.length < 1) {
+                    if (!url || url.length < 1) {
                         lastRoute = [ThrioNavigator lastRoute];
                     } else {
                         lastRoute = [ThrioNavigator getLastRouteByUrl:url];
@@ -234,15 +238,59 @@ NS_ASSUME_NONNULL_BEGIN
                      handler:
      ^void (NSDictionary<NSString *, id> *arguments,
             ThrioIdCallback _Nullable result) {
-                NSString *url = arguments[@"url"];
-                NSArray *allRoutes =
-                    [ThrioNavigator getAllRoutesByUrl:url];
+                NSString *url = [arguments[@"url"] isKindOfClass:NSNull.class] ? nil : arguments[@"url"];
+                NSArray *allRoutes;
+                if (!url || url.length < 1) {
+                    allRoutes = [ThrioNavigator allRoutes];
+                } else {
+                    allRoutes = [ThrioNavigator getAllRoutesByUrl:url];
+                }
                 NSMutableArray *allIndexes = [NSMutableArray array];
                 for (NavigatorPageRoute *route in allRoutes) {
                     [allIndexes addObject:route.settings.index];
                 }
                 if (result) {
                     result(allIndexes);
+                }
+            }];
+}
+
+- (void)_onLastRoute {
+    [_channel registryMethod:@"lastRoute"
+                     handler:
+     ^void (NSDictionary<NSString *, id> *arguments,
+            ThrioIdCallback _Nullable result) {
+                if (result) {
+                    NSString *url = [arguments[@"url"] isKindOfClass:NSNull.class] ? nil : arguments[@"url"];
+                    NavigatorPageRoute *lastRoute = nil;
+                    if (!url || url.length < 1) {
+                        lastRoute = [ThrioNavigator lastRoute];
+                    } else {
+                        lastRoute = [ThrioNavigator getLastRouteByUrl:url];
+                    }
+                    result(lastRoute.settings.name);
+                }
+            }];
+}
+
+- (void)_onGetAllRoutes {
+    [_channel registryMethod:@"allRoutes"
+                     handler:
+     ^void (NSDictionary<NSString *, id> *arguments,
+            ThrioIdCallback _Nullable result) {
+                NSString *url = [arguments[@"url"] isKindOfClass:NSNull.class] ? nil : arguments[@"url"];
+                NSArray *allRoutes;
+                if (!url || url.length < 1) {
+                    allRoutes = [ThrioNavigator allRoutes];
+                } else {
+                    allRoutes = [ThrioNavigator getAllRoutesByUrl:url];
+                }
+                NSMutableArray *allNames = [NSMutableArray array];
+                for (NavigatorPageRoute *route in allRoutes) {
+                    [allNames addObject:route.settings.name];
+                }
+                if (result) {
+                    result(allNames);
                 }
             }];
 }

--- a/ios/Classes/Navigator/NavigatorRouteReceiveChannel.m
+++ b/ios/Classes/Navigator/NavigatorRouteReceiveChannel.m
@@ -50,9 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
         [self _onPop];
         [self _onPopTo];
         [self _onRemove];
-        
-        [self _onLastIndex];
-        [self _onGetAllIndexes];
+
         [self _onLastRoute];
         [self _onGetAllRoutes];
 
@@ -212,46 +210,6 @@ NS_ASSUME_NONNULL_BEGIN
                                             result(@(r));
                                         }
                                     }];
-            }];
-}
-
-- (void)_onLastIndex {
-    [_channel registryMethod:@"lastIndex"
-                     handler:
-     ^void (NSDictionary<NSString *, id> *arguments,
-            ThrioIdCallback _Nullable result) {
-                if (result) {
-                    NSString *url = [arguments[@"url"] isKindOfClass:NSNull.class] ? nil : arguments[@"url"];
-                    NavigatorPageRoute *lastRoute = nil;
-                    if (!url || url.length < 1) {
-                        lastRoute = [ThrioNavigator lastRoute];
-                    } else {
-                        lastRoute = [ThrioNavigator getLastRouteByUrl:url];
-                    }
-                    result(lastRoute.settings.index);
-                }
-            }];
-}
-
-- (void)_onGetAllIndexes {
-    [_channel registryMethod:@"allIndexes"
-                     handler:
-     ^void (NSDictionary<NSString *, id> *arguments,
-            ThrioIdCallback _Nullable result) {
-                NSString *url = [arguments[@"url"] isKindOfClass:NSNull.class] ? nil : arguments[@"url"];
-                NSArray *allRoutes;
-                if (!url || url.length < 1) {
-                    allRoutes = [ThrioNavigator allRoutes];
-                } else {
-                    allRoutes = [ThrioNavigator getAllRoutesByUrl:url];
-                }
-                NSMutableArray *allIndexes = [NSMutableArray array];
-                for (NavigatorPageRoute *route in allRoutes) {
-                    [allIndexes addObject:route.settings.index];
-                }
-                if (result) {
-                    result(allIndexes);
-                }
             }];
 }
 

--- a/ios/Classes/Navigator/NavigatorRouteSettings.h
+++ b/ios/Classes/Navigator/NavigatorRouteSettings.h
@@ -45,6 +45,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong, readonly) NSNumber *index;
 
+@property (nonatomic, copy, readonly) NSString *name;
+
 @property (nonatomic, assign, readonly) BOOL nested;
 
 @property (nonatomic, copy, readonly, nullable) id params;

--- a/ios/Classes/Navigator/NavigatorRouteSettings.m
+++ b/ios/Classes/Navigator/NavigatorRouteSettings.m
@@ -85,6 +85,10 @@ NS_ASSUME_NONNULL_BEGIN
     };
 }
 
+- (NSString *)name {
+    return [NSString stringWithFormat:@"%@ %@", !_index ? @0 : _index, _url];
+}
+
 - (NSString *)description {
     return [NSString stringWithFormat:@"settings: %@", [self toArguments]];
 }

--- a/ios/Classes/Navigator/ThrioNavigator+JsonDeserializers.h
+++ b/ios/Classes/Navigator/ThrioNavigator+JsonDeserializers.h
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019 Hellobike Group
+// Copyright (c) 2020 foxsofter
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -20,50 +20,16 @@
 // IN THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
-#import "ThrioTypes.h"
+#import "ThrioRegistryMap.h"
+#import "ThrioNavigator.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface ThrioModule : NSObject
+@interface ThrioNavigator (JsonDeserializers)
 
-/// Module entrypoint method.
-///
-+ (void)init:(ThrioModule *)rootModule;
++ (ThrioRegistryMap *)jsonDeserializers;
 
-+ (void)init:(ThrioModule *)rootModule multiEngineEnabled:(BOOL)enabled;
-
-/// A function for registering a module.
-///
-/// Should be called in `onModuleRegister`.
-///
-- (void)registerModule:(ThrioModule *)module;
-
-/// A function for module initialization that will call  the `onPageRegister`, `onModuleInit` and `onModuleAsyncInit`
-/// methods of all modules.
-///
-/// Should only be called once when the app startups.
-///
-- (void)initModule;
-
-/// A function for registering submodules.
-///
-- (void)onModuleRegister;
-
-/// A function for module initialization.
-///
-- (void)onModuleInit;
-
-/// A function for module asynchronous initialization.
-///
-- (void)onModuleAsyncInit;
-
-/// Startup the flutter engine with `entrypoint`.
-///
-/// Should be called in `onModuleAsyncInit`. Subsequent calls will return immediately if the entrypoint is the same.
-///
-/// Do not override this method.
-///
-- (void)startupFlutterEngineWithEntrypoint:(NSString *)entrypoint;
++ (id _Nullable)deserializeParams:(NSDictionary *_Nullable)params;
 
 @end
 

--- a/ios/Classes/Navigator/ThrioNavigator+JsonDeserializers.h
+++ b/ios/Classes/Navigator/ThrioNavigator+JsonDeserializers.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (ThrioRegistryMap *)jsonDeserializers;
 
-+ (id _Nullable)deserializeParams:(NSDictionary *_Nullable)params;
++ (id _Nullable)deserializeParams:(id _Nullable)params;
 
 @end
 

--- a/ios/Classes/Navigator/ThrioNavigator+JsonDeserializers.m
+++ b/ios/Classes/Navigator/ThrioNavigator+JsonDeserializers.m
@@ -1,0 +1,65 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 foxsofter
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+#import "ThrioNavigator+JsonDeserializers.h"
+
+@implementation ThrioNavigator (JsonDeserializers)
+
++ (ThrioRegistryMap *)jsonDeserializers {
+    id deserializers = objc_getAssociatedObject(self, _cmd);
+    if (!deserializers) {
+        deserializers = [ThrioRegistryMap map];
+        objc_setAssociatedObject(self, _cmd, deserializers, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+    return deserializers;
+}
+
++ (id _Nullable)deserializeParams:(NSDictionary *_Nullable)params {
+    if (!params) {
+        return nil;
+    }
+    if (![params isKindOfClass:NSDictionary.class]) {
+        return params;
+    }
+    NSString *type = params[@"__thrio_TParams__"];
+    if (!type) {
+        return params;
+    }
+    // 来自 FlutterEngine
+    ThrioRegistryMap *jsonDeserializers = [ThrioNavigator jsonDeserializers];
+    ThrioJsonDeserializer deserializer = jsonDeserializers[type];
+    if (!deserializer) {
+        for (NSString *key in jsonDeserializers) {
+            if ([key hasSuffix:type]) {
+                deserializer = jsonDeserializers[key];
+                break;
+            }
+        }
+    }
+    if (!deserializer) {
+        return params;
+    }
+    return deserializer(params);
+}
+
+@end

--- a/ios/Classes/Navigator/ThrioNavigator+JsonDeserializers.m
+++ b/ios/Classes/Navigator/ThrioNavigator+JsonDeserializers.m
@@ -34,13 +34,11 @@
     return deserializers;
 }
 
-+ (id _Nullable)deserializeParams:(NSDictionary *_Nullable)params {
-    if (!params) {
-        return nil;
-    }
-    if (![params isKindOfClass:NSDictionary.class]) {
++ (id _Nullable)deserializeParams:(id _Nullable)params {
+    if (!params || ![params isKindOfClass:NSDictionary.class]) {
         return params;
     }
+
     NSString *type = params[@"__thrio_TParams__"];
     if (!type) {
         return params;

--- a/ios/Classes/Navigator/ThrioNavigator+JsonSerializers.h
+++ b/ios/Classes/Navigator/ThrioNavigator+JsonSerializers.h
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2019 Hellobike Group
+// Copyright (c) 2020 foxsofter
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -20,50 +20,16 @@
 // IN THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
-#import "ThrioTypes.h"
+#import "ThrioNavigator.h"
+#import "ThrioRegistryMap.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface ThrioModule : NSObject
+@interface ThrioNavigator (JsonSerializers)
 
-/// Module entrypoint method.
-///
-+ (void)init:(ThrioModule *)rootModule;
++ (ThrioRegistryMap *)jsonSerializers;
 
-+ (void)init:(ThrioModule *)rootModule multiEngineEnabled:(BOOL)enabled;
-
-/// A function for registering a module.
-///
-/// Should be called in `onModuleRegister`.
-///
-- (void)registerModule:(ThrioModule *)module;
-
-/// A function for module initialization that will call  the `onPageRegister`, `onModuleInit` and `onModuleAsyncInit`
-/// methods of all modules.
-///
-/// Should only be called once when the app startups.
-///
-- (void)initModule;
-
-/// A function for registering submodules.
-///
-- (void)onModuleRegister;
-
-/// A function for module initialization.
-///
-- (void)onModuleInit;
-
-/// A function for module asynchronous initialization.
-///
-- (void)onModuleAsyncInit;
-
-/// Startup the flutter engine with `entrypoint`.
-///
-/// Should be called in `onModuleAsyncInit`. Subsequent calls will return immediately if the entrypoint is the same.
-///
-/// Do not override this method.
-///
-- (void)startupFlutterEngineWithEntrypoint:(NSString *)entrypoint;
++ (NSDictionary *_Nullable)serializeParams:(id _Nullable)params;
 
 @end
 

--- a/ios/Classes/Navigator/ThrioNavigator+JsonSerializers.m
+++ b/ios/Classes/Navigator/ThrioNavigator+JsonSerializers.m
@@ -33,10 +33,11 @@
     return serializers;
 }
 
-+ (NSDictionary *_Nullable)serializeParams:(id _Nullable)params {
++ (id _Nullable)serializeParams:(id _Nullable)params {
     if (!params) {
         return nil;
     }
+
     // 已经序列化过了
     if ([params isKindOfClass:NSDictionary.class] &&
         [params containsObject:@"__thrio_TParams__"]) {

--- a/ios/Classes/Navigator/ThrioNavigator.h
+++ b/ios/Classes/Navigator/ThrioNavigator.h
@@ -409,6 +409,10 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 + (NavigatorPageRoute *_Nullable)getLastRouteByUrl:(NSString *)url;
 
+/// Returns all route of the page in the navigation stack.
+///
++ (NSArray *)allRoutes;
+
 /// Returns all route of the page with `url` in the navigation stack.
 ///
 + (NSArray *)getAllRoutesByUrl:(NSString *)url;

--- a/ios/Classes/Navigator/ThrioNavigator.m
+++ b/ios/Classes/Navigator/ThrioNavigator.m
@@ -350,7 +350,15 @@ NS_ASSUME_NONNULL_BEGIN
     return lastRoute;
 }
 
++ (NSArray *)allRoutes {
+    return [self _getAllRoutesByUrl:nil];
+}
+
 + (NSArray *)getAllRoutesByUrl:(NSString *)url {
+    return [self _getAllRoutesByUrl:url];
+}
+
++ (NSArray *)_getAllRoutesByUrl:(NSString *_Nullable)url {
     NSMutableArray *allRoutes = [NSMutableArray array];
     NSEnumerator *allNvcs = self.navigationControllers.allObjects.reverseObjectEnumerator;
     for (UINavigationController *nvc in allNvcs) {

--- a/ios/Classes/Navigator/UINavigationController+Navigator.h
+++ b/ios/Classes/Navigator/UINavigationController+Navigator.h
@@ -65,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NavigatorPageRoute *_Nullable)thrio_getLastRouteByUrl:(NSString *)url;
 
-- (NSArray *)thrio_getAllRoutesByUrl:(NSString *)url;
+- (NSArray *)thrio_getAllRoutesByUrl:(NSString *_Nullable)url;
 
 - (NavigatorPageRoute *)thrio_getLastRouteByEntrypoint:(NSString *)entrypoint;
 

--- a/ios/Classes/Navigator/UINavigationController+Navigator.m
+++ b/ios/Classes/Navigator/UINavigationController+Navigator.m
@@ -341,7 +341,7 @@ NS_ASSUME_NONNULL_BEGIN
     return [vc thrio_getLastRouteByUrl:url];
 }
 
-- (NSArray *)thrio_getAllRoutesByUrl:(NSString *)url {
+- (NSArray *)thrio_getAllRoutesByUrl:(NSString *_Nullable)url {
     NSArray *vcs = self.viewControllers;
     NSMutableArray *routes = [NSMutableArray array];
     for (UIViewController *vc in vcs) {

--- a/ios/Classes/Navigator/UINavigationController+Navigator.m
+++ b/ios/Classes/Navigator/UINavigationController+Navigator.m
@@ -28,6 +28,7 @@
 #import "NavigatorPageNotifyProtocol.h"
 #import "NavigatorRouteSettings.h"
 #import "ThrioNavigator+Internal.h"
+#import "ThrioNavigator+JsonDeserializers.h"
 #import "ThrioNavigator+PageBuilders.h"
 #import "ThrioNavigator+PageObservers.h"
 #import "ThrioNavigator+RouteObservers.h"
@@ -610,11 +611,13 @@ NS_ASSUME_NONNULL_BEGIN
     return viewController;
 }
 
-- (UIViewController *_Nullable)thrio_createNativeViewControllerWithUrl:(NSString *)url params:(NSDictionary *)params {
+- (UIViewController *_Nullable)thrio_createNativeViewControllerWithUrl:(NSString *)url
+                                                                params:(NSDictionary *)params {
     UIViewController *viewController;
     NavigatorPageBuilder builder = [ThrioNavigator pageBuilders][url];
     if (builder) {
-        viewController = builder(params);
+        id deserializeParams = [ThrioNavigator deserializeParams:params];
+        viewController = builder(deserializeParams);
         if (viewController.thrio_hidesNavigationBar_ == nil) {
             viewController.thrio_hidesNavigationBar_ = @NO;
         }

--- a/ios/Classes/Navigator/UIViewController+Navigator.h
+++ b/ios/Classes/Navigator/UIViewController+Navigator.h
@@ -72,7 +72,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NavigatorPageRoute *_Nullable)thrio_getLastRouteByUrl:(NSString *)url;
 
-- (NSArray *)thrio_getAllRoutesByUrl:(NSString *)url;
+- (NSArray *)thrio_getAllRoutesByUrl:(NSString *_Nullable)url;
 
 @end
 

--- a/ios/Classes/Navigator/UIViewController+Navigator.m
+++ b/ios/Classes/Navigator/UIViewController+Navigator.m
@@ -372,11 +372,11 @@ NS_ASSUME_NONNULL_BEGIN
     return route;
 }
 
-- (NSArray *)thrio_getAllRoutesByUrl:(NSString *)url {
+- (NSArray *)thrio_getAllRoutesByUrl:(NSString *_Nullable)url {
     NSMutableArray *routes = [NSMutableArray array];
     NavigatorPageRoute *first = self.thrio_firstRoute;
     do {
-        if ([first.settings.url isEqualToString:url]) {
+        if (!url || url.length < 1 || [first.settings.url isEqualToString:url]) {
             [routes addObject:first];
         }
     } while ((first = first.next));

--- a/ios/Classes/Thrio.h
+++ b/ios/Classes/Thrio.h
@@ -32,6 +32,8 @@
 #import "ThrioChannel.h"
 #import "ThrioLogger.h"
 #import "ThrioModule.h"
+#import "ThrioModuleJsonDeserializer.h"
+#import "ThrioModuleJsonSerializer.h"
 #import "ThrioModulePageBuilder.h"
 #import "ThrioModulePageObserver.h"
 #import "ThrioModuleRouteObserver.h"

--- a/ios/Classes/ThrioTypes.h
+++ b/ios/Classes/ThrioTypes.h
@@ -46,6 +46,14 @@ typedef void (^ThrioIdCallback)(id _Nullable);
 ///
 typedef void (^ThrioWillPopCallback)(ThrioBoolCallback);
 
+/// Signature for a block that deserialize json map to object.
+///
+typedef id _Nullable (^ThrioJsonDeserializer)(NSDictionary *params);
+
+/// Signature for a block that serializer json object to map.
+///
+typedef NSDictionary *_Nullable (^ThrioJsonSerializer)(id);
+
 /// Signature for a block that handlers channel method invocation.
 ///
 typedef void (^ThrioMethodHandler)(NSDictionary<NSString *, id> *arguments, ThrioIdCallback _Nullable result);

--- a/ios/thrio.podspec
+++ b/ios/thrio.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'thrio'
-  s.version          = '1.1.1'
+  s.version          = '1.2.0'
   s.summary          = 'Thrio makes it easy and fast to add flutter to existing mobile applications, and provide a simple and consistent navigator API.'
   s.description      = <<-DESC
 A flutter plugin which enables hybrid integration of flutter for existing ios or android apps.

--- a/lib/src/navigator/navigator_observer_manager.dart
+++ b/lib/src/navigator/navigator_observer_manager.dart
@@ -119,10 +119,6 @@ class NavigatorObserverManager extends NavigatorObserver {
           _currentPopRoutes.clear();
         });
       }
-      // 清空 poppedResult
-      ThrioNavigatorImplement.shared()
-          .poppedResultCallbacks
-          .remove(route.settings.name);
     }
     // 清空 poppedResult
     ThrioNavigatorImplement.shared()

--- a/lib/src/navigator/navigator_observer_manager.dart
+++ b/lib/src/navigator/navigator_observer_manager.dart
@@ -125,6 +125,10 @@ class NavigatorObserverManager extends NavigatorObserver {
           .poppedResultCallbacks
           .remove(route.settings.name);
     }
+    // 清空 poppedResult
+    ThrioNavigatorImplement.shared()
+        .poppedResultCallbacks
+        .remove(route.settings.name);
   }
 
   @override

--- a/lib/src/navigator/navigator_observer_manager.dart
+++ b/lib/src/navigator/navigator_observer_manager.dart
@@ -91,8 +91,7 @@ class NavigatorObserverManager extends NavigatorObserver {
                   AppLifecycleState.resumed) {
                 verbose(
                   'didRemove: url->${route.settings.url} '
-                  'index->${route.settings.index} '
-                  'params->${route.settings.params}',
+                  'index->${route.settings.index} ',
                 );
                 ThrioNavigatorImplement.shared()
                     .routeObservers

--- a/lib/src/navigator/navigator_page_notify.dart
+++ b/lib/src/navigator/navigator_page_notify.dart
@@ -30,7 +30,7 @@ import 'navigator_types.dart';
 import 'navigator_widget.dart';
 import 'thrio_navigator_implement.dart';
 
-class NavigatorPageNotify<T> extends StatefulWidget {
+class NavigatorPageNotify extends StatefulWidget {
   const NavigatorPageNotify({
     Key key,
     @required this.name,
@@ -44,15 +44,15 @@ class NavigatorPageNotify<T> extends StatefulWidget {
 
   final NavigatorParamsCallback onPageNotify;
 
-  final T initialParams;
+  final dynamic initialParams;
 
   final Widget child;
 
   @override
-  _NavigatorPageNotifyState<T> createState() => _NavigatorPageNotifyState<T>();
+  _NavigatorPageNotifyState createState() => _NavigatorPageNotifyState();
 }
 
-class _NavigatorPageNotifyState<T> extends State<NavigatorPageNotify<T>> {
+class _NavigatorPageNotifyState extends State<NavigatorPageNotify> {
   NavigatorPageRoute _route;
 
   Stream _notifyStream;
@@ -64,7 +64,7 @@ class _NavigatorPageNotifyState<T> extends State<NavigatorPageNotify<T>> {
     if (mounted) {
       if (widget.initialParams != null) {
         // ignore: avoid_as
-        widget.onPageNotify(<T>() => widget.initialParams as T);
+        widget.onPageNotify(widget.initialParams);
       }
     }
   }
@@ -104,16 +104,12 @@ class _NavigatorPageNotifyState<T> extends State<NavigatorPageNotify<T>> {
               .jsonDeserializers[type]
               ?.call(params.cast<String, dynamic>());
           if (paramsInstance != null) {
-            // ignore: avoid_as
-            widget.onPageNotify(<type>() => paramsInstance as type);
+            widget.onPageNotify(paramsInstance);
             return;
           }
         }
       }
-      // ignore: unused_local_variable
-      final type = params.runtimeType;
-      // ignore: avoid_as
-      widget.onPageNotify(<type>() => params as type);
+      widget.onPageNotify(params);
     } else {
       widget.onPageNotify(null);
     }

--- a/lib/src/navigator/navigator_route_receive_channel.dart
+++ b/lib/src/navigator/navigator_route_receive_channel.dart
@@ -83,15 +83,15 @@ class NavigatorRouteReceiveChannel {
       });
 
   Stream onPageNotify({
-    @required String url,
-    @required int index,
     @required String name,
+    String url,
+    int index,
   }) =>
       _channel
           .onEventStream('__onNotify__')
           .where((arguments) =>
-              arguments.containsValue(url) &&
               arguments.containsValue(name) &&
+              (url == null || arguments.containsValue(url)) &&
               (index == null || arguments.containsValue(index)))
           .map((arguments) => arguments['params']);
 
@@ -102,8 +102,8 @@ class NavigatorRouteReceiveChannel {
       if (typeString != null) {
         final jsonDeserializers =
             ThrioNavigatorImplement.shared().jsonDeserializers;
-        final type = jsonDeserializers.keys
-            .lastWhere((it) => it.toString() == typeString);
+        final type = jsonDeserializers.keys.lastWhere((it) =>
+            it.toString() == typeString || typeString.endsWith(it.toString()));
         final paramsInstance = ThrioNavigatorImplement.shared()
             .jsonDeserializers[type]
             ?.call(params.cast<String, dynamic>());

--- a/lib/src/navigator/navigator_route_send_channel.dart
+++ b/lib/src/navigator/navigator_route_send_channel.dart
@@ -20,6 +20,7 @@
 // IN THE SOFTWARE.
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 
 import '../channel/thrio_channel.dart';
 import '../extension/thrio_object.dart';
@@ -104,6 +105,26 @@ class NavigatorRouteSendChannel {
 
   Future<List<int>> allIndexes({@required String url}) =>
       _channel.invokeListMethod<int>('allIndexes', {'url': url});
+
+  Future<RouteSettings> lastRoute({String url}) {
+    final arguments = (url?.isEmpty ?? true)
+        ? <String, dynamic>{}
+        : <String, dynamic>{'url': url};
+    return _channel
+        .invokeMethod<String>('lastRoute', arguments)
+        .then<RouteSettings>((value) => RouteSettings(name: value));
+  }
+
+  Future<List<RouteSettings>> allRoutes({String url}) {
+    final arguments = (url?.isEmpty ?? true)
+        ? <String, dynamic>{}
+        : <String, dynamic>{'url': url};
+    return _channel
+        .invokeListMethod<String>('allRoutes', arguments)
+        .then<List<RouteSettings>>((values) => values
+            .map<RouteSettings>((value) => RouteSettings(name: value))
+            .toList());
+  }
 
   Future<bool> setPopDisabled({
     @required String url,

--- a/lib/src/navigator/navigator_types.dart
+++ b/lib/src/navigator/navigator_types.dart
@@ -27,7 +27,7 @@ typedef NavigatorPageBuilder = Widget Function(RouteSettings settings);
 
 /// Signature of callbacks with generic parameters with type `T`.
 ///
-typedef NavigatorParamsCallback = void Function(T Function<T>() factory);
+typedef NavigatorParamsCallback = void Function(dynamic params);
 
 /// Signature of callbacks with RouteSettings.
 ///

--- a/lib/src/navigator/navigator_widget.dart
+++ b/lib/src/navigator/navigator_widget.dart
@@ -267,16 +267,11 @@ class NavigatorWidgetState extends State<NavigatorWidget> {
               final paramsInstance = ThrioNavigatorImplement.shared()
                   .jsonDeserializers[type]
                   ?.call(params.cast<String, dynamic>());
-              // ignore: avoid_as
-              poppedResultCallback(<type>() => paramsInstance as type);
+              poppedResultCallback(paramsInstance);
               return;
             }
           }
-
-          // ignore: unused_local_variable
-          final paramsType = params.runtimeType;
-          // ignore: avoid_as
-          poppedResultCallback(<paramsType>() => params as paramsType);
+          poppedResultCallback(params);
         }
       }
     }

--- a/lib/src/navigator/navigator_widget.dart
+++ b/lib/src/navigator/navigator_widget.dart
@@ -251,30 +251,28 @@ class NavigatorWidgetState extends State<NavigatorWidget> {
       if (params == null) {
         poppedResultCallback(null);
       } else {
-        final type = params.runtimeType;
-        if (type != null && params is Map) {
+        if (params is Map && params.containsKey('__thrio_TParams__')) {
           // ignore: avoid_as
           final typeString = params['__thrio_TParams__'] as String;
-          if (type != null) {
-            final jsonDeserializers =
-                ThrioNavigatorImplement.shared().jsonDeserializers;
-            final type = jsonDeserializers.keys.lastWhere(
-                (it) => it.toString() == typeString,
-                orElse: () => null);
+          if (typeString != null) {
+            final type = ThrioNavigatorImplement.shared()
+                .jsonDeserializers
+                .keys
+                .lastWhere(
+                    (it) =>
+                        it.toString() == typeString ||
+                        typeString.endsWith(it.toString()),
+                    orElse: () => null);
             if (type != null) {
+              final paramsInstance = ThrioNavigatorImplement.shared()
+                  .jsonDeserializers[type]
+                  ?.call(params.cast<String, dynamic>());
               // ignore: avoid_as
-              poppedResultCallback(<type>() {
-                final paramsInstance = ThrioNavigatorImplement.shared()
-                    .jsonDeserializers[type]
-                    ?.call(params.cast<String, dynamic>());
-                if (paramsInstance != null && paramsInstance is type) {
-                  return paramsInstance;
-                }
-                return null;
-              });
+              poppedResultCallback(<type>() => paramsInstance as type);
+              return;
             }
           }
-        } else {
+
           // ignore: unused_local_variable
           final paramsType = params.runtimeType;
           // ignore: avoid_as

--- a/lib/src/navigator/thrio_navigator.dart
+++ b/lib/src/navigator/thrio_navigator.dart
@@ -101,11 +101,24 @@ abstract class ThrioNavigator {
   /// Returns the index of the page that was last pushed to the navigation
   /// stack.
   ///
+  @Deprecated('will be remove at version 1.3.0')
   static Future<int> lastIndex({String url}) =>
       ThrioNavigatorImplement.shared().lastIndex(url: url);
 
   /// Returns all index of the page with `url` in the navigation stack.
   ///
+  @Deprecated('will be remove at version 1.3.0')
   static Future<List<int>> allIndexes({@required String url}) =>
       ThrioNavigatorImplement.shared().allIndexes(url: url);
+
+  /// Returns the route of the page that was last pushed to the navigation
+  /// stack.
+  ///
+  static Future<RouteSettings> lastRoute({String url}) =>
+      ThrioNavigatorImplement.shared().lastRoute(url: url);
+
+  /// Returns all route of the page with `url` in the navigation stack.
+  ///
+  static Future<List<RouteSettings>> allRoutes({String url}) =>
+      ThrioNavigatorImplement.shared().allRoutes(url: url);
 }

--- a/lib/src/navigator/thrio_navigator_implement.dart
+++ b/lib/src/navigator/thrio_navigator_implement.dart
@@ -174,6 +174,12 @@ class ThrioNavigatorImplement {
   Future<List<int>> allIndexes({@required String url}) =>
       _sendChannel?.allIndexes(url: url);
 
+  Future<RouteSettings> lastRoute({String url}) =>
+      _sendChannel?.lastRoute(url: url);
+
+  Future<List<RouteSettings>> allRoutes({String url}) =>
+      _sendChannel?.allRoutes(url: url);
+
   Future<bool> setPopDisabled({
     @required String url,
     int index,

--- a/lib/src/navigator/thrio_navigator_implement.dart
+++ b/lib/src/navigator/thrio_navigator_implement.dart
@@ -24,7 +24,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
 import '../channel/thrio_channel.dart';
-import '../extension/thrio_object.dart';
 import '../module/module_context.dart';
 import '../registry/registry_map.dart';
 import 'navigator_logger.dart';
@@ -107,10 +106,7 @@ class ThrioNavigatorImplement {
     NavigatorParamsCallback poppedResult,
   }) =>
       _sendChannel
-          ?.push(
-              url: url,
-              params: _serializeParams<TParams>(params),
-              animated: animated)
+          ?.push<TParams>(url: url, params: params, animated: animated)
           ?.then<int>((index) {
         if (poppedResult != null && index != null && index > 0) {
           final routeName = '$index $url';
@@ -135,19 +131,19 @@ class ThrioNavigatorImplement {
     @required String name,
     TParams params,
   }) =>
-      _sendChannel?.notify(
+      _sendChannel?.notify<TParams>(
         name: name,
         url: url,
         index: index,
-        params: _serializeParams<TParams>(params),
+        params: params,
       );
 
   Future<bool> pop<TParams>({
     TParams params,
     bool animated = true,
   }) =>
-      _sendChannel?.pop(
-        params: _serializeParams<TParams>(params),
+      _sendChannel?.pop<TParams>(
+        params: params,
         animated: animated,
       );
 
@@ -190,14 +186,14 @@ class ThrioNavigatorImplement {
       );
 
   Stream onPageNotify({
-    @required String url,
-    @required int index,
     @required String name,
+    String url,
+    int index,
   }) =>
       _receiveChannel?.onPageNotify(
+        name: name,
         url: url,
         index: index,
-        name: name,
       );
 
   void hotRestart() {
@@ -210,20 +206,4 @@ class ThrioNavigatorImplement {
 
   RegistryMap<RegExp, RouteTransitionsBuilder> get routeTransitionsBuilders =>
       _routeTransitionsBuilders;
-
-  dynamic _serializeParams<TParams>(TParams params) {
-    if (params == null) {
-      return null;
-    }
-    final type = params.runtimeType;
-    if (type != dynamic && params.isComplexType) {
-      final serializeParams = jsonSerializers[type]
-          ?.call(<type>() => params as type); // ignore: avoid_as
-      if (serializeParams != null) {
-        serializeParams['__thrio_TParams__'] = type.toString();
-        return serializeParams;
-      }
-    }
-    return params;
-  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: thrio
 description: Thrio makes it easy and fast to add flutter to existing mobile applications, and provide a simple and consistent navigator APIs.
-version: 1.1.1
+version: 1.2.0
 homepage: https://github.com/hellobike/flutter_thrio
 
 environment:


### PR DESCRIPTION
* fix: issue #123，解决`1.1.0`版本中存在的 pop native 到原生 poppedResult 不调用的问题
* feat: 支持在所有页面间传递Json对象，为相关 API 添加泛型支持
* feat: Flutter端添加 `lastRoute`,     `allRoutes` 两个新的 API
* feat: 删除 `lastIndex`，`allIndexes` 这两个 API
